### PR TITLE
docs: expand API and determinism guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Production-grade toolkit for Bitcoin market intelligence: strict data contracts, deterministic pipelines, validation, observability, and release artifacts.
 
+Documentation: [Quickstart](docs/QUICKSTART.md) · [API usage](docs/API.md) · [Security](docs/SECURITY.md)
+
 ## Features
 
 * **Operational modes:** `quick_brief`, `pro_report`, `signal_scan`, `execution_plan`, `stress_test`, `backtest_hint`
@@ -49,11 +51,33 @@ python -m cli.run --mode execution_plan --input examples/input.sample.json --out
 python tests/validate_output.py out.json
 ```
 
+Deterministic runs can set a fixed timestamp and seed:
+
+```bash
+PYTHONHASHSEED=0 python -m cli.run --mode execution_plan \
+  --input examples/input.sample.json --out out.json --fixed-ts 2025-01-01T00:00:00Z
+```
+
 ## Docker
 
 ```bash
 docker compose up --build
 docker compose run --rm app --mode quick_brief --input /data/input.json --out /data/out.json
+```
+
+For API usage see [docs/API.md](docs/API.md).
+
+## FastAPI server
+
+```bash
+uvicorn btcmi.api:app --host 0.0.0.0 --port 8000
+```
+
+Docker:
+
+```bash
+docker run --rm -p 8000:8000 btcmi-api \
+  uvicorn btcmi.api:app --host 0.0.0.0 --port 8000
 ```
 
 ## Modes
@@ -84,12 +108,13 @@ python scripts/verify_checksums.py
 
 * Prometheus job: `ops/prometheus/job.sample.yml`
 * Grafana dashboard: `ops/grafana/dashboard.json`
+* Expose metrics locally: `python ops/metrics/exporter.py` → `http://localhost:9101/metrics`
 
 ## Releases
 
 1. Tag `vX.Y.Z`
 2. Create GitHub Release with `CHANGELOG.md` excerpt
-3. Attach distributable ZIP as artifact
+3. Attach distributable ZIP as artifact; include `CHECKSUMS.SHA256` and `provenance/sbom.spdx.json`
 
 ## Contributing
 
@@ -98,7 +123,7 @@ python scripts/verify_checksums.py
 
 ## Security
 
-Refer to `docs/SECURITY.md`. Report issues via GitHub Issues (Security).
+Refer to [docs/SECURITY.md](docs/SECURITY.md). Report issues via GitHub Issues (Security).
 
 ## License
 

--- a/btcmi/api.py
+++ b/btcmi/api.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+import datetime as dt
+from pathlib import Path
+from fastapi import FastAPI, HTTPException
+from . import engine_v1 as v1, engine_v2 as v2
+from .schema_util import validate_json
+from .logging_util import log, new_trace_id
+
+app = FastAPI()
+
+
+def _run_v1(data, fixed_ts):
+    scenario = data["scenario"]
+    window = data["window"]
+    feats = data.get("features", {})
+    norm = v1.normalize(feats)
+    base, weights, contrib = v1.base_signal(scenario, norm)
+    ng = v1.nagr_score(data.get("nagr_nodes", []))
+    overall = v1.combine(base, ng)
+    exp = set(v1.NORM_SCALE.keys())
+    comp = len([k for k in feats.keys() if k in exp]) / (len(exp) or 1)
+    conf = round(0.5 + 0.5 * comp, 3)
+    notes = []
+    if comp < 0.6:
+        notes.append("low_feature_completeness")
+    asof = fixed_ts or dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    return {
+        "asof": asof,
+        "summary": {
+            "scenario": scenario,
+            "window": window,
+            "overall_signal": round(overall, 6),
+            "confidence": conf,
+            "router_path": f"{scenario}/v1",
+            "nagr_score": round(ng, 6),
+            "advisories": notes,
+        },
+        "details": {
+            "normalized_features": {k: round(v, 6) for k, v in norm.items()},
+            "weights": v1.SCENARIO_WEIGHTS[scenario],
+            "contributions": {k: round(v, 6) for k, v in contrib.items()},
+            "constraints_applied": False,
+            "diagnostics": {"completeness": round(comp, 3), "notes": notes},
+        },
+    }
+
+
+def _run_v2(data, fixed_ts):
+    scenario = data["scenario"]
+    window = data["window"]
+    f1 = data.get("features_micro", {})
+    f2 = data.get("features_mezo", {})
+    f3 = data.get("features_macro", {})
+    vol_pctl = float(data.get("vol_regime_pctl", 0.5))
+    n1 = v2.normalize_layer(f1, v2.SCALES["L1"])
+    n2 = v2.normalize_layer(f2, v2.SCALES["L2"])
+    n3 = v2.normalize_layer(f3, v2.SCALES["L3"])
+    w1 = v2.layer_equal_weights(n1)
+    w2 = v2.layer_equal_weights(n2)
+    w3 = v2.layer_equal_weights(n3)
+    s1, _ = v2.level_signal(n1, w1, data.get("nagr_nodes", []))
+    s2, _ = v2.level_signal(n2, w2, data.get("nagr_nodes", []))
+    s3, _ = v2.level_signal(n3, w3, data.get("nagr_nodes", []))
+    regime, alphas = v2.router_weights(vol_pctl)
+    overall = v2.combine_levels(s1, s2, s3, alphas)
+    coverage = sum(len(x) > 0 for x in [n1, n2, n3]) / 3.0
+    conf = round(0.5 + 0.5 * min(coverage, 1.0), 3)
+    notes = []
+    asof = fixed_ts or dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    return {
+        "asof": asof,
+        "summary": {
+            "scenario": scenario,
+            "window": window,
+            "overall_signal": round(overall, 6),
+            "confidence": conf,
+            "router_path": f"{scenario}/v2.fractal",
+            "nagr_score": 0.0,
+            "advisories": notes,
+            "overall_signal_L1": round(s1, 6),
+            "overall_signal_L2": round(s2, 6),
+            "overall_signal_L3": round(s3, 6),
+            "level_weights": alphas,
+        },
+        "details": {
+            "normalized_micro": {k: round(v, 6) for k, v in n1.items()},
+            "normalized_mezo": {k: round(v, 6) for k, v in n2.items()},
+            "normalized_macro": {k: round(v, 6) for k, v in n3.items()},
+            "router_regime": regime,
+            "diagnostics": {"completeness": round(coverage, 3), "notes": notes},
+        },
+    }
+
+
+@app.post("/run")
+def run(data: dict, fractal: bool = False, fixed_ts: str | None = None):
+    trace = new_trace_id()
+    try:
+        validate_json(data, Path(__file__).resolve().parents[1] / "input_schema.json")
+    except Exception as e:
+        log("warn", "input_schema_validation_failed", trace=trace, error=str(e))
+    mode = data.get("mode")
+    if mode == "v1" and fractal:
+        log("warn", "mode_flag_mismatch", trace=trace, mode=mode, fractal_flag=True)
+    if mode == "v2.fractal" and not fractal:
+        log("warn", "mode_flag_mismatch", trace=trace, mode=mode, fractal_flag=False)
+    out = _run_v2(data, fixed_ts) if fractal or mode == "v2.fractal" else _run_v1(data, fixed_ts)
+    try:
+        validate_json(out, Path(__file__).resolve().parents[1] / "output_schema.json")
+    except Exception as e:
+        log("error", "output_schema_validation_failed", trace=trace, error=str(e))
+        raise HTTPException(status_code=400, detail="output_schema_validation_failed")
+    log("info", "run_ok", trace=trace, fractal=(fractal or mode == "v2.fractal"), overall=out["summary"]["overall_signal"])
+    return out

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,54 @@
+# API Usage
+
+## FastAPI server
+
+Install dependencies:
+
+```bash
+pip install fastapi uvicorn
+```
+
+Run the server:
+
+```bash
+uvicorn btcmi.api:app --host 0.0.0.0 --port 8000
+```
+
+POST an input payload:
+
+```bash
+curl -X POST "http://localhost:8000/run?fractal=true&fixed_ts=2025-01-01T00:00:00Z" \
+  -H "Content-Type: application/json" \
+  -d @examples/intraday_fractal.json
+```
+
+## Docker
+
+Build and run with Docker:
+
+```bash
+docker build -t btcmi-api -f docker/Dockerfile .
+docker run --rm -p 8000:8000 btcmi-api \
+  uvicorn btcmi.api:app --host 0.0.0.0 --port 8000
+```
+
+## Determinism and seeds
+
+Use a fixed timestamp and Python hash seed for reproducible runs:
+
+```bash
+PYTHONHASHSEED=0 uvicorn btcmi.api:app --host 0.0.0.0 --port 8000
+```
+
+## Metrics
+
+Expose basic metrics:
+
+```bash
+python ops/metrics/exporter.py
+# metrics at http://localhost:9101/metrics
+```
+
+## Release artifacts
+
+Published releases include checksums and an SBOM in `provenance/`. See `CHECKSUMS.SHA256` and `provenance/sbom.spdx.json` for verification.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -3,3 +3,18 @@
 python3 cli/btcmi.py run --input examples/intraday.json --out outputs/intraday_v1.out.json --fixed-ts 2025-01-01T00:00:00Z
 ## v2 Fractal
 python3 cli/btcmi.py run --input examples/intraday_fractal.json --out outputs/intraday_v2.out.json --fractal --fixed-ts 2025-01-01T00:00:00Z
+
+## Deterministic mode
+
+Set a fixed timestamp and seed to make runs reproducible:
+
+```bash
+PYTHONHASHSEED=0 python3 cli/btcmi.py run --input examples/intraday.json \
+  --out outputs/intraday_seeded.json --fixed-ts 2025-01-01T00:00:00Z
+```
+
+Metrics can be exposed separately:
+
+```bash
+python ops/metrics/exporter.py  # http://localhost:9101/metrics
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 jsonschema>=4.22.0
+fastapi>=0.115.0
+uvicorn>=0.23.0


### PR DESCRIPTION
## Summary
- document deterministic CLI runs and seed usage
- add FastAPI server with API usage docs and Docker examples
- note metrics endpoint, release artifacts, and security links

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi>=0.115.0)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b14fd1035083298a24df493417c541