### PR TITLE
docs: add mkdocs configuration and schema docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,8 @@ jobs:
         env:
           PYTHONPATH: .
         run: pytest -q --disable-warnings --maxfail=1
+
+      - name: Build docs
+        run: |
+          python scripts/generate_schema_docs.py
+          mkdocs build --strict

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release Docs
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Generate schema docs
+        run: python scripts/generate_schema_docs.py
+      - name: Build documentation
+        run: mkdocs build --strict
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 build/
 *.log
 docker/*.local.*
+site/

--- a/docs/schemas/input_schema.md
+++ b/docs/schemas/input_schema.md
@@ -1,0 +1,15 @@
+# BTCMI Input
+
+## Properties
+
+- **scenario** (*string*): 
+- **window** (*string*): 
+- **asof** (*string*): 
+- **mode** (*string*): 
+- **features** (*object*): 
+- **nagr_nodes** (*array*): 
+- **features_micro** (*object*): 
+- **features_mezo** (*object*): 
+- **features_macro** (*object*): 
+- **vol_regime_pctl** (*number*): 
+- **freshness_seconds** (*number*): 

--- a/docs/schemas/output_schema.md
+++ b/docs/schemas/output_schema.md
@@ -1,0 +1,7 @@
+# BTCMI Output
+
+## Properties
+
+- **asof** (*string*): 
+- **summary** (*object*): 
+- **details** (*object*): 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: BTC Market Intelligence
+theme:
+  name: material
+nav:
+  - Quickstart: QUICKSTART.md
+  - Security: SECURITY.md
+  - Schemas:
+      - Input Schema: schemas/input_schema.md
+      - Output Schema: schemas/output_schema.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 jsonschema>=4.22.0
+mkdocs>=1.5
+mkdocs-material>=9.0

--- a/scripts/generate_schema_docs.py
+++ b/scripts/generate_schema_docs.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Generate Markdown documentation from JSON Schema files."""
+from __future__ import annotations
+import json
+import pathlib
+
+def schema_to_markdown(schema_path: pathlib.Path) -> str:
+    schema = json.loads(schema_path.read_text())
+    title = schema.get("title", schema_path.stem)
+    lines = [f"# {title}", ""]
+    if "description" in schema:
+        lines.extend([schema["description"], ""])
+    properties = schema.get("properties", {})
+    if properties:
+        lines.extend(["## Properties", ""])
+        for name, prop in properties.items():
+            typ = prop.get("type", "any")
+            desc = prop.get("description", "")
+            lines.append(f"- **{name}** (*{typ}*): {desc}")
+    lines.append("")
+    return "\n".join(lines)
+
+def main() -> None:
+    docs_dir = pathlib.Path("docs/schemas")
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    for schema_file in ["input_schema.json", "output_schema.json"]:
+        path = pathlib.Path(schema_file)
+        if not path.exists():
+            continue
+        markdown = schema_to_markdown(path)
+        out_path = docs_dir / f"{path.stem}.md"
+        out_path.write_text(markdown)
+        print(f"Wrote {out_path}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- configure MkDocs with the Material theme and existing docs
- auto-generate schema docs from JSON schemas
- build docs in CI and deploy on release

## Testing
- `python scripts/generate_schema_docs.py`
- `pytest`
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pip install -r requirements.txt pytest` *(fails: Could not find a version that satisfies the requirement mkdocs>=1.5)*
- `mkdocs build` *(fails: command not found: mkdocs)*

------
https://chatgpt.com/codex/tasks/task_e_68b14fce25388329b444f01ff4ddb011