### PR TITLE
Add FastAPI API with metrics and health check

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException, Response
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest
+
+from btcmi.schema_util import validate_json
+from cli.btcmi import run_v1, run_v2
+
+app = FastAPI()
+
+# Registry mapping modes to runner implementations
+RUNNERS = {
+    "v1": run_v1,
+    "v2.fractal": run_v2,
+}
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+SCHEMA_REGISTRY = {
+    "input": BASE_DIR / "input_schema.json",
+    "output": BASE_DIR / "output_schema.json",
+}
+
+REQUEST_COUNTER = Counter("btcmi_requests_total", "Total HTTP requests", ["endpoint"])
+
+
+@app.middleware("http")
+async def count_requests(request, call_next):
+    response = await call_next(request)
+    REQUEST_COUNTER.labels(endpoint=request.url.path).inc()
+    return response
+
+
+@app.post("/run")
+async def run_endpoint(payload: dict):
+    mode = payload.get("mode", "v1")
+    runner = RUNNERS.get(mode)
+    if runner is None:
+        raise HTTPException(status_code=400, detail=f"unknown mode: {mode}")
+    result = runner(payload, None, "/dev/null")
+    return result
+
+
+@app.post("/validate/{schema_name}")
+async def validate_endpoint(schema_name: str, payload: dict):
+    schema_path = SCHEMA_REGISTRY.get(schema_name)
+    if schema_path is None:
+        raise HTTPException(status_code=404, detail="schema not found")
+    try:
+        validate_json(payload, schema_path)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"valid": True}
+
+
+@app.get("/metrics")
+async def metrics() -> Response:
+    data = generate_latest()
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)
+
+
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    return {"status": "ok"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,11 @@ version = "1.2.1"
 description = "BTC Market Intelligence with Fractal Engine v2."
 readme = "docs/QUICKSTART.md"
 requires-python = ">=3.10"
-dependencies = ["jsonschema>=4.22.0"]
+dependencies = [
+    "jsonschema>=4.22.0",
+    "fastapi>=0.111.0",
+    "prometheus-client>=0.19.0",
+]
 authors = [{name="BTCMI Team"}]
 license = {text="MIT"}
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 jsonschema>=4.22.0
+fastapi>=0.111.0
+prometheus-client>=0.19.0


### PR DESCRIPTION
## Summary
- add FastAPI application exposing `/run`, `/validate`, `/metrics`, and `/healthz`
- wire `/run` to existing runners and `/validate` to JSON schema checks
- expose Prometheus metrics and declare new dependencies

## Testing
- `python -m ruff check api/app.py requirements.txt pyproject.toml`
- `python -m ruff format api/app.py`
- `pytest`
- `pre-commit run --files api/app.py requirements.txt pyproject.toml` *(fails: command not found)*
- `pip install pre-commit` *(fails: 403 - Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b14fbee39c8329998c90cc965bfa17