### PR TITLE
Normalize numeric inputs only

### DIFF
--- a/btcmi/engine_v1.py
+++ b/btcmi/engine_v1.py
@@ -1,29 +1,80 @@
 from __future__ import annotations
 from typing import Dict, Tuple, Any
 import math
+
 FeatureMap = Dict[str, float]
 SCENARIO_WEIGHTS = {
-    "intraday": {"price_change_pct":0.35,"volume_change_pct":0.25,"funding_rate_bps":-0.10,"oi_change_pct":0.20,"onchain_active_addrs_change_pct":0.10},
-    "scalp":    {"price_change_pct":0.45,"volume_change_pct":0.30,"funding_rate_bps":-0.05,"oi_change_pct":0.15,"onchain_active_addrs_change_pct":0.05},
-    "swing":    {"price_change_pct":0.25,"volume_change_pct":0.15,"funding_rate_bps":-0.10,"oi_change_pct":0.25,"onchain_active_addrs_change_pct":0.25},
+    "intraday": {
+        "price_change_pct": 0.35,
+        "volume_change_pct": 0.25,
+        "funding_rate_bps": -0.10,
+        "oi_change_pct": 0.20,
+        "onchain_active_addrs_change_pct": 0.10,
+    },
+    "scalp": {
+        "price_change_pct": 0.45,
+        "volume_change_pct": 0.30,
+        "funding_rate_bps": -0.05,
+        "oi_change_pct": 0.15,
+        "onchain_active_addrs_change_pct": 0.05,
+    },
+    "swing": {
+        "price_change_pct": 0.25,
+        "volume_change_pct": 0.15,
+        "funding_rate_bps": -0.10,
+        "oi_change_pct": 0.25,
+        "onchain_active_addrs_change_pct": 0.25,
+    },
 }
-NORM_SCALE = {"price_change_pct":2.0,"volume_change_pct":50.0,"funding_rate_bps":10.0,"oi_change_pct":20.0,"onchain_active_addrs_change_pct":20.0}
+NORM_SCALE = {
+    "price_change_pct": 2.0,
+    "volume_change_pct": 50.0,
+    "funding_rate_bps": 10.0,
+    "oi_change_pct": 20.0,
+    "onchain_active_addrs_change_pct": 20.0,
+}
+
+
 def normalize(features: FeatureMap) -> FeatureMap:
-    return {k: math.tanh(v/NORM_SCALE.get(k,1.0)) for k,v in features.items() if isinstance(v,(int,float))}
+    return {
+        k: math.tanh(v / NORM_SCALE.get(k, 1.0))
+        for k, v in features.items()
+        if isinstance(v, (int, float)) and not isinstance(v, bool)
+    }
+
+
 def completeness(features: FeatureMap) -> float:
-    exp=set(NORM_SCALE.keys()); pres=set(k for k in features.keys() if k in exp); 
-    return len(pres)/len(exp) if exp else 1.0
+    exp = set(NORM_SCALE.keys())
+    pres = set(k for k in features.keys() if k in exp)
+    return len(pres) / len(exp) if exp else 1.0
+
+
 def base_signal(scenario: str, norm: FeatureMap):
-    weights=SCENARIO_WEIGHTS[scenario]; s=0.0; den=0.0; contrib={}
-    for k,w in weights.items():
+    weights = SCENARIO_WEIGHTS[scenario]
+    s = 0.0
+    den = 0.0
+    contrib = {}
+    for k, w in weights.items():
         if k in norm:
-            c=norm[k]*w; contrib[k]=c; s+=c; den+=abs(w)
-    return (max(-1.0,min(1.0,s/den)) if den else 0.0, weights, contrib)
+            c = norm[k] * w
+            contrib[k] = c
+            s += c
+            den += abs(w)
+    return (max(-1.0, min(1.0, s / den)) if den else 0.0, weights, contrib)
+
+
 def nagr_score(nodes: Any) -> float:
-    if not nodes: return 0.0
-    num=0.0; den=0.0
-    for n in nodes: 
-        w=float(n.get("weight",0.0)); sc=float(n.get("score",0.0)); num+=w*sc; den+=abs(w)
-    return max(-1.0,min(1.0, num/den if den else 0.0))
+    if not nodes:
+        return 0.0
+    num = 0.0
+    den = 0.0
+    for n in nodes:
+        w = float(n.get("weight", 0.0))
+        sc = float(n.get("score", 0.0))
+        num += w * sc
+        den += abs(w)
+    return max(-1.0, min(1.0, num / den if den else 0.0))
+
+
 def combine(base: float, nagr: float) -> float:
-    return max(-1.0, min(1.0, 0.7*base + 0.3*nagr))
+    return max(-1.0, min(1.0, 0.7 * base + 0.3 * nagr))

--- a/btcmi/engine_v2.py
+++ b/btcmi/engine_v2.py
@@ -2,46 +2,87 @@ from __future__ import annotations
 from typing import Dict, Tuple, List
 import math
 
-def tanh_norm(x: float, s: float) -> float:
-    return math.tanh(x/s) if s else 0.0
 
-def normalize_layer(feats: Dict[str, float], scales: Dict[str, float]) -> Dict[str, float]:
-    return {k: tanh_norm(v, scales.get(k,1.0)) for k,v in feats.items() if isinstance(v,(int,float))}
+def tanh_norm(x: float, s: float) -> float:
+    return math.tanh(x / s) if s else 0.0
+
+
+def normalize_layer(
+    feats: Dict[str, float], scales: Dict[str, float]
+) -> Dict[str, float]:
+    return {
+        k: tanh_norm(v, scales.get(k, 1.0))
+        for k, v in feats.items()
+        if isinstance(v, (int, float)) and not isinstance(v, bool)
+    }
+
 
 def linear_score(norm: Dict[str, float], weights: Dict[str, float]):
-    s=0.0; den=0.0; contrib={}
-    for k,w in weights.items():
+    s = 0.0
+    den = 0.0
+    contrib = {}
+    for k, w in weights.items():
         if k in norm:
-            c=norm[k]*w; contrib[k]=c; s+=c; den+=abs(w)
-    score = max(-1.0, min(1.0, s/den)) if den else 0.0
+            c = norm[k] * w
+            contrib[k] = c
+            s += c
+            den += abs(w)
+    score = max(-1.0, min(1.0, s / den)) if den else 0.0
     return score, contrib
 
+
 def nagr(nodes: List[dict]) -> float:
-    if not nodes: return 0.0
-    num=sum(float(n.get("weight",0.0))*float(n.get("score",0.0)) for n in nodes)
-    den=sum(abs(float(n.get("weight",0.0))) for n in nodes) or 1.0
-    return max(-1.0, min(1.0, num/den))
+    if not nodes:
+        return 0.0
+    num = sum(float(n.get("weight", 0.0)) * float(n.get("score", 0.0)) for n in nodes)
+    den = sum(abs(float(n.get("weight", 0.0))) for n in nodes) or 1.0
+    return max(-1.0, min(1.0, num / den))
+
 
 def level_signal(norm, weights, nagr_nodes):
     base, contrib = linear_score(norm, weights)
-    return 0.8*base + 0.2*nagr(nagr_nodes), contrib
+    return 0.8 * base + 0.2 * nagr(nagr_nodes), contrib
+
 
 def router_weights(vol_pctl: float):
-    if vol_pctl < 0.2:   return "low", {"L1":0.15, "L2":0.35, "L3":0.50}
-    if vol_pctl < 0.6:   return "mid", {"L1":0.25, "L2":0.40, "L3":0.35}
-    return "high", {"L1":0.40, "L2":0.40, "L3":0.20}
+    if vol_pctl < 0.2:
+        return "low", {"L1": 0.15, "L2": 0.35, "L3": 0.50}
+    if vol_pctl < 0.6:
+        return "mid", {"L1": 0.25, "L2": 0.40, "L3": 0.35}
+    return "high", {"L1": 0.40, "L2": 0.40, "L3": 0.20}
+
 
 def combine_levels(L1: float, L2: float, L3: float, w):
-    s = w["L1"]*L1 + w["L2"]*L2 + w["L3"]*L3
+    s = w["L1"] * L1 + w["L2"] * L2 + w["L3"] * L3
     return max(-1.0, min(1.0, s))
 
+
 SCALES = {
-  "L1": {"price_change_pct":2.0,"volume_change_pct":50.0,"funding_rate_bps":10.0,"oi_change_pct":20.0,"micro_liquidity_gaps":5.0},
-  "L2": {"oi_term_structure_slope":0.5,"funding_premium_spread":0.5,"net_positioning_index":0.5,"liquidation_heatmap_entropy":1.0},
-  "L3": {"hashrate_trend":0.5,"active_addrs_trend":0.5,"supply_in_profit_pct":0.5,"macro_regime_score":1.0}
+    "L1": {
+        "price_change_pct": 2.0,
+        "volume_change_pct": 50.0,
+        "funding_rate_bps": 10.0,
+        "oi_change_pct": 20.0,
+        "micro_liquidity_gaps": 5.0,
+    },
+    "L2": {
+        "oi_term_structure_slope": 0.5,
+        "funding_premium_spread": 0.5,
+        "net_positioning_index": 0.5,
+        "liquidation_heatmap_entropy": 1.0,
+    },
+    "L3": {
+        "hashrate_trend": 0.5,
+        "active_addrs_trend": 0.5,
+        "supply_in_profit_pct": 0.5,
+        "macro_regime_score": 1.0,
+    },
 }
 
-def layer_equal_weights(norm: Dict[str,float]) -> Dict[str,float]:
-    if not norm: return {}
-    n = len(norm); w = 1.0/n
+
+def layer_equal_weights(norm: Dict[str, float]) -> Dict[str, float]:
+    if not norm:
+        return {}
+    n = len(norm)
+    w = 1.0 / n
     return {k: w for k in norm.keys()}

--- a/tests/test_normalize_no_bool.py
+++ b/tests/test_normalize_no_bool.py
@@ -1,0 +1,22 @@
+import math
+
+from btcmi.engine_v1 import NORM_SCALE, normalize
+from btcmi.engine_v2 import SCALES, normalize_layer
+
+
+def test_v1_ignores_booleans():
+    features = {"price_change_pct": 1.0, "volume_change_pct": True}
+    result = normalize(features)
+    assert "volume_change_pct" not in result
+    assert result == {
+        "price_change_pct": math.tanh(1.0 / NORM_SCALE["price_change_pct"])
+    }
+
+
+def test_v2_ignores_booleans():
+    feats = {"price_change_pct": 1.0, "volume_change_pct": True}
+    result = normalize_layer(feats, SCALES["L1"])
+    assert "volume_change_pct" not in result
+    assert result == {
+        "price_change_pct": math.tanh(1.0 / SCALES["L1"]["price_change_pct"])
+    }


### PR DESCRIPTION
## Summary
- skip boolean features during normalization
- test to ensure only numeric inputs are normalized

## Testing
- `ruff format btcmi/engine_v1.py btcmi/engine_v2.py tests/test_normalize_no_bool.py`
- `ruff check btcmi/engine_v1.py btcmi/engine_v2.py tests/test_normalize_no_bool.py`
- `pytest`

Labels: codex


------
https://chatgpt.com/codex/tasks/task_e_68b1a42e251c8329a19626148f2858a4