### PR TITLE
Avoid masking schema errors when jsonschema present

### DIFF
--- a/btcmi/schema_util.py
+++ b/btcmi/schema_util.py
@@ -6,6 +6,14 @@ def validate_json(data, schema_path):
     schema = load_json(schema_path)
     try:
         from jsonschema import Draft202012Validator
+    except ImportError:
+        if schema.get("type") == "object":
+            if not isinstance(data, dict):
+                raise ValueError("root: must be object")
+            for req in schema.get("required", []):
+                if req not in data:
+                    raise ValueError(f"{req}: is a required property")
+    else:
         v = Draft202012Validator(schema)
         errors = sorted(v.iter_errors(data), key=lambda e: e.path)
         if errors:
@@ -14,10 +22,3 @@ def validate_json(data, schema_path):
                 loc = "/".join(map(str, e.path))
                 msgs.append(f"{loc}: {e.message}")
             raise ValueError("\n".join(msgs))
-    except Exception:
-        if schema.get("type") == "object":
-            if not isinstance(data, dict):
-                raise ValueError("root: must be object")
-            for req in schema.get("required", []):
-                if req not in data:
-                    raise ValueError(f"{req}: is a required property")

--- a/tests/test_schema_util.py
+++ b/tests/test_schema_util.py
@@ -1,0 +1,18 @@
+import json
+import pytest
+from btcmi.schema_util import validate_json
+
+def test_validate_json_additional_properties(tmp_path):
+    pytest.importorskip("jsonschema")
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {"foo": {"type": "string"}},
+        "required": ["foo"],
+        "additionalProperties": False,
+    }
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text(json.dumps(schema))
+    data = {"foo": "bar", "extra": "baz"}
+    with pytest.raises(ValueError):
+        validate_json(data, schema_path)


### PR DESCRIPTION
## Summary
- Catch only ImportError when importing jsonschema and run validation outside the try to surface real schema errors
- Add regression test ensuring validate_json raises ValueError for extra properties

## Testing
- `pytest -q`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1ce699a9c83298f1d3e7ce036d5bf