### PR TITLE
docs: update CLI invocation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ pip install -e .
 Run:
 
 ```bash
-python -m cli.run --mode execution_plan --input examples/input.sample.json --out out.json
+# Option 1: use module path directly
+python -m cli.btcmi run --mode execution_plan --input examples/input.sample.json --out out.json
+# Option 2: after installation, invoke the script
+btcmi run --mode execution_plan --input examples/input.sample.json --out out.json
 python tests/validate_output.py out.json
 ```
 


### PR DESCRIPTION
## Summary
- clarify README run instructions to use `cli.btcmi` module or `btcmi` script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement httpx>=0.27.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dd1fe9888329868d96fa31a254fb