### PR TITLE
refactor: centralize number checking utility

### DIFF
--- a/btcmi/__init__.py
+++ b/btcmi/__init__.py
@@ -1,2 +1,2 @@
 __version__="1.2.1"
-__all__=["engine_v1","engine_v2","logging_util","logging_cfg","schema_util"]
+__all__=["engine_v1","engine_v2","logging_util","logging_cfg","schema_util","utils"]

--- a/btcmi/engine_v1.py
+++ b/btcmi/engine_v1.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 from typing import Dict, Tuple, Any
 import math
-
-
-def is_number(x):
-    return isinstance(x, (int, float)) and not isinstance(x, bool)
+from btcmi.utils import is_number
 
 
 FeatureMap = Dict[str, float]

--- a/btcmi/engine_v2.py
+++ b/btcmi/engine_v2.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 from typing import Dict, Tuple, List
 import math
-
-
-def is_number(x):
-    return isinstance(x, (int, float)) and not isinstance(x, bool)
+from btcmi.utils import is_number
 
 def tanh_norm(x: float, s: float) -> float:
     return math.tanh(x/s) if s else 0.0

--- a/btcmi/utils.py
+++ b/btcmi/utils.py
@@ -1,0 +1,2 @@
+def is_number(x):
+    return isinstance(x, (int, float)) and not isinstance(x, bool)


### PR DESCRIPTION
## Summary
- add shared `is_number` helper in new `btcmi.utils` module
- use `is_number` from `btcmi.utils` in `engine_v1` and `engine_v2`
- expose `utils` module via `btcmi.__all__`

## Testing
- `pre-commit run --files btcmi/utils.py btcmi/engine_v1.py btcmi/engine_v2.py btcmi/__init__.py` *(fails: command not found)*
- `python -m pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `python -m pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*
- `pytest` *(fails: RuntimeError: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1de27fce08329804ef74c81a7b24d