### PR TITLE
Add docstrings to engine modules

### DIFF
--- a/btcmi/engine_v1.py
+++ b/btcmi/engine_v1.py
@@ -1,5 +1,7 @@
+"""First generation signal calculation utilities."""
+
 from __future__ import annotations
-from typing import Dict, Tuple, Any
+from typing import Dict, Any
 import math
 from btcmi.utils import is_number
 
@@ -12,24 +14,72 @@ SCENARIO_WEIGHTS = {
 }
 NORM_SCALE = {"price_change_pct":2.0,"volume_change_pct":50.0,"funding_rate_bps":10.0,"oi_change_pct":20.0,"onchain_active_addrs_change_pct":20.0}
 def normalize(features: FeatureMap) -> FeatureMap:
+    """Scale raw feature values using hyperbolic tangent.
+
+    Args:
+        features: Mapping from feature names to raw numeric values.
+
+    Returns:
+        A feature map with each numeric value normalized to the [-1, 1] range.
+
+    """
     return {k: math.tanh(v / NORM_SCALE.get(k, 1.0)) for k, v in features.items() if is_number(v)}
 
 
 def completeness(features: FeatureMap) -> float:
+    """Compute fraction of expected features present with numeric values.
+
+    Args:
+        features: Mapping of provided features.
+
+    Returns:
+        The proportion of expected features that are present and numeric.
+
+    """
     exp = set(NORM_SCALE.keys())
     pres = {k for k, v in features.items() if k in exp and is_number(v)}
     return len(pres) / len(exp) if exp else 1.0
 def base_signal(scenario: str, norm: FeatureMap):
-    weights=SCENARIO_WEIGHTS[scenario]; s=0.0; den=0.0; contrib={}
-    for k,w in weights.items():
+    """Calculate weighted signal for a trading scenario.
+
+    Args:
+        scenario: Scenario key selecting the weight profile.
+        norm: Normalized feature values.
+
+    Returns:
+        Tuple of overall score, applied weights, and individual contributions.
+
+    """
+    weights = SCENARIO_WEIGHTS[scenario]; s = 0.0; den = 0.0; contrib = {}
+    for k, w in weights.items():
         if k in norm:
-            c=norm[k]*w; contrib[k]=c; s+=c; den+=abs(w)
-    return (max(-1.0,min(1.0,s/den)) if den else 0.0, weights, contrib)
+            c = norm[k] * w; contrib[k] = c; s += c; den += abs(w)
+    return (max(-1.0, min(1.0, s / den)) if den else 0.0, weights, contrib)
 def nagr_score(nodes: Any) -> float:
-    if not nodes: return 0.0
-    num=0.0; den=0.0
-    for n in nodes: 
-        w=float(n.get("weight",0.0)); sc=float(n.get("score",0.0)); num+=w*sc; den+=abs(w)
-    return max(-1.0,min(1.0, num/den if den else 0.0))
+    """Aggregate a network graph rating score.
+
+    Args:
+        nodes: Iterable of node dictionaries with ``weight`` and ``score``.
+
+    Returns:
+        Weighted average score clipped to [-1, 1].
+
+    """
+    if not nodes:
+        return 0.0
+    num = 0.0; den = 0.0
+    for n in nodes:
+        w = float(n.get("weight", 0.0)); sc = float(n.get("score", 0.0)); num += w * sc; den += abs(w)
+    return max(-1.0, min(1.0, num / den if den else 0.0))
 def combine(base: float, nagr: float) -> float:
-    return max(-1.0, min(1.0, 0.7*base + 0.3*nagr))
+    """Blend base and network scores.
+
+    Args:
+        base: Baseline signal score.
+        nagr: Network aggregated score.
+
+    Returns:
+        Weighted combination clipped to [-1, 1].
+
+    """
+    return max(-1.0, min(1.0, 0.7 * base + 0.3 * nagr))

--- a/btcmi/engine_v2.py
+++ b/btcmi/engine_v2.py
@@ -1,39 +1,113 @@
+"""Second generation layered signal engine utilities."""
+
 from __future__ import annotations
-from typing import Dict, Tuple, List
+from typing import Dict, List
 import math
 from btcmi.utils import is_number
 
 def tanh_norm(x: float, s: float) -> float:
-    return math.tanh(x/s) if s else 0.0
+    """Normalize a value using hyperbolic tangent scaling.
+
+    Args:
+        x: Input value.
+        s: Scale factor determining steepness.
+
+    Returns:
+        The normalized value in [-1, 1].
+
+    """
+    return math.tanh(x / s) if s else 0.0
 
 def normalize_layer(feats: Dict[str, float], scales: Dict[str, float]) -> Dict[str, float]:
+    """Apply normalization to a layer's feature set.
+
+    Args:
+        feats: Raw feature values for the layer.
+        scales: Scaling factors keyed by feature name.
+
+    Returns:
+        Dictionary of normalized feature values.
+
+    """
     return {k: tanh_norm(v, scales.get(k, 1.0)) for k, v in feats.items() if is_number(v)}
 
 def linear_score(norm: Dict[str, float], weights: Dict[str, float]):
-    s=0.0; den=0.0; contrib={}
-    for k,w in weights.items():
+    """Compute weighted linear score for normalized features.
+
+    Args:
+        norm: Normalized feature values.
+        weights: Weight assigned to each feature.
+
+    Returns:
+        Tuple of overall score and per-feature contributions.
+
+    """
+    s = 0.0; den = 0.0; contrib = {}
+    for k, w in weights.items():
         if k in norm:
-            c=norm[k]*w; contrib[k]=c; s+=c; den+=abs(w)
-    score = max(-1.0, min(1.0, s/den)) if den else 0.0
+            c = norm[k] * w; contrib[k] = c; s += c; den += abs(w)
+    score = max(-1.0, min(1.0, s / den)) if den else 0.0
     return score, contrib
 
 def nagr(nodes: List[dict]) -> float:
-    if not nodes: return 0.0
-    num=sum(float(n.get("weight",0.0))*float(n.get("score",0.0)) for n in nodes)
-    den=sum(abs(float(n.get("weight",0.0))) for n in nodes) or 1.0
-    return max(-1.0, min(1.0, num/den))
+    """Aggregate network graph ratings.
+
+    Args:
+        nodes: Sequence of node dicts with ``weight`` and ``score``.
+
+    Returns:
+        Weighted average score clipped to [-1, 1].
+
+    """
+    if not nodes:
+        return 0.0
+    num = sum(float(n.get("weight", 0.0)) * float(n.get("score", 0.0)) for n in nodes)
+    den = sum(abs(float(n.get("weight", 0.0))) for n in nodes) or 1.0
+    return max(-1.0, min(1.0, num / den))
 
 def level_signal(norm, weights, nagr_nodes):
+    """Blend linear feature score with network rating for one level.
+
+    Args:
+        norm: Normalized feature values.
+        weights: Weight mapping for the level.
+        nagr_nodes: Network graph nodes contributing to NAGR score.
+
+    Returns:
+        Tuple of combined level signal and feature contributions.
+
+    """
     base, contrib = linear_score(norm, weights)
-    return 0.8*base + 0.2*nagr(nagr_nodes), contrib
+    return 0.8 * base + 0.2 * nagr(nagr_nodes), contrib
 
 def router_weights(vol_pctl: float):
+    """Select level weights based on volume percentile.
+
+    Args:
+        vol_pctl: Market volume percentile in [0, 1].
+
+    Returns:
+        A tuple of descriptor string and weight mapping for levels.
+
+    """
     if vol_pctl < 0.2:   return "low", {"L1":0.15, "L2":0.35, "L3":0.50}
     if vol_pctl < 0.6:   return "mid", {"L1":0.25, "L2":0.40, "L3":0.35}
     return "high", {"L1":0.40, "L2":0.40, "L3":0.20}
 
 def combine_levels(L1: float, L2: float, L3: float, w):
-    s = w["L1"]*L1 + w["L2"]*L2 + w["L3"]*L3
+    """Merge signals from all levels using provided weights.
+
+    Args:
+        L1: Level-one signal value.
+        L2: Level-two signal value.
+        L3: Level-three signal value.
+        w: Weight mapping for each level.
+
+    Returns:
+        Combined score clipped to [-1, 1].
+
+    """
+    s = w["L1"] * L1 + w["L2"] * L2 + w["L3"] * L3
     return max(-1.0, min(1.0, s))
 
 SCALES = {
@@ -42,7 +116,17 @@ SCALES = {
   "L3": {"hashrate_trend":0.5,"active_addrs_trend":0.5,"supply_in_profit_pct":0.5,"macro_regime_score":1.0}
 }
 
-def layer_equal_weights(norm: Dict[str,float]) -> Dict[str,float]:
-    if not norm: return {}
-    n = len(norm); w = 1.0/n
+def layer_equal_weights(norm: Dict[str, float]) -> Dict[str, float]:
+    """Generate equal weights for a layer's features.
+
+    Args:
+        norm: Normalized feature values for a layer.
+
+    Returns:
+        Mapping assigning an equal weight to each feature.
+
+    """
+    if not norm:
+        return {}
+    n = len(norm); w = 1.0 / n
     return {k: w for k in norm.keys()}


### PR DESCRIPTION
## Summary
- add module and function docstrings to engine_v1
- document public functions in engine_v2

## Testing
- `ruff check --select D btcmi/engine_v1.py btcmi/engine_v2.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'api')*

------
https://chatgpt.com/codex/tasks/task_e_68b1dfbdc9208329842a0a49d1147ba0