### PR TITLE
Add validation and metrics tests

### DIFF
--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -3,8 +3,10 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
+from prometheus_client import CONTENT_TYPE_LATEST
+from prometheus_client.parser import text_string_to_metric_families
 
-from api.app import app, RUNNERS
+from api.app import app, RUNNERS, REQUEST_COUNTER
 
 R = Path(__file__).resolve().parents[1]
 
@@ -36,3 +38,35 @@ def test_run_runner_exception(monkeypatch):
     payload = _load_example("intraday")
     resp = client.post("/run", json=payload)
     assert resp.status_code == 500
+
+
+def test_validate_input_valid():
+    client = TestClient(app)
+    payload = _load_example("intraday")
+    resp = client.post("/validate/input", json=payload)
+    assert resp.status_code == 200
+    assert resp.json() == {"valid": True}
+
+
+def test_validate_input_invalid():
+    client = TestClient(app)
+    resp = client.post("/validate/input", json={"schema_version": "2.0.0"})
+    assert resp.status_code == 400
+
+
+def test_metrics_prometheus_text_and_counters():
+    client = TestClient(app)
+    base_validate = REQUEST_COUNTER.labels(endpoint="/validate/input")._value.get()
+
+    payload = _load_example("intraday")
+    client.post("/validate/input", json=payload)
+    client.post("/validate/input", json={"schema_version": "2.0.0"})
+
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == CONTENT_TYPE_LATEST
+
+    metrics = {mf.name: mf for mf in text_string_to_metric_families(resp.text)}
+    samples = {s.labels["endpoint"]: s.value for s in metrics["btcmi_requests"].samples}
+
+    assert samples["/validate/input"] == base_validate + 2


### PR DESCRIPTION
## Summary
- test API validation endpoint for valid and invalid payloads
- ensure metrics endpoint outputs Prometheus text and counters increase

## Testing
- `pytest tests/test_api_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e37fa0948329b0bb162582baeab9