### PR TITLE
chore: add formatting and linting tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,15 @@ default_language_version:
   python: python3.11
 
 repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.4
     hooks:
       - id: ruff
         args: ["--fix"]
-      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,11 @@
 - Усі залежності мають бути встановлені через:
   ```bash
   pip install -r requirements.txt -c constraints.txt
+  pip install .[dev] -c constraints.txt
+  ```
+- Перед комітом запускайте перевірки стилю та форматування:
+  ```bash
+  black .
+  ruff check .
+  ```
+

--- a/constraints.txt
+++ b/constraints.txt
@@ -14,6 +14,7 @@ httpx==0.27.0
 # Testing and tooling
 pytest==8.3.3
 pytest-cov==5.0.0
+black==24.4.2
 ruff==0.6.4
 mypy==1.11.2
 pip-audit==2.7.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,5 +15,18 @@ dependencies = [
 ]
 authors = [{name="BTCMI Team"}]
 license = {text="MIT"}
+[project.optional-dependencies]
+dev = [
+    "black>=24.4.2",
+    "ruff>=0.6.4",
+]
 [project.scripts]
 btcmi = "cli.btcmi:main"
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"


### PR DESCRIPTION
## Summary
- add black and ruff dev dependencies and configuration
- document usage of black and ruff in CONTRIBUTING
- wire black into pre-commit and pin in constraints

## Testing
- `pip install -r requirements.txt -c constraints.txt` (failed: ResolutionImpossible: The user requested httpx>=0.27.0, The user requested (constraint) httpx==0.27.0)
- `pip install .[dev] -c constraints.txt` (failed: Could not find a version that satisfies the requirement setuptools>=68)
- `pre-commit run --files pyproject.toml .pre-commit-config.yaml CONTRIBUTING.md constraints.txt` (command not found: pre-commit)
- `pytest` (failed: ModuleNotFoundError: No module named 'api')

------
https://chatgpt.com/codex/tasks/task_e_68b1e51c03648329a9a9964a46faa484