### PR TITLE
Add Python 3.10 CI workflow with linters and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,30 @@
 name: CI
 
 on:
-  workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
+  workflow_dispatch:
 
 jobs:
-  build-test:
+  lint-test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ "3.10", "3.11", "3.12" ]
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            constraints.txt
 
-      - name: Install tools and deps (no package build)
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          # якщо є requirements.txt/constraints.txt — встановимо
           if [ -f requirements.txt ]; then
             if [ -f constraints.txt ]; then
               pip install -r requirements.txt -c constraints.txt
@@ -34,18 +32,15 @@ jobs:
               pip install -r requirements.txt
             fi
           fi
-          pip install pytest pytest-cov ruff mypy
+          pip install black flake8 pytest
 
-      - name: Lint with ruff (non-blocking)
-        run: ruff check . || echo "ruff warnings"
+      - name: Lint with black
+        run: black --check .
 
-      - name: Type check with mypy (non-blocking)
-        run: |
-          if [ -d "btcmi" ]; then
-            mypy btcmi || echo "mypy warnings"
-          fi
+      - name: Lint with flake8
+        run: flake8 .
 
-      - name: Run tests with pytest
+      - name: Run tests
         env:
           PYTHONPATH: .
-        run: pytest -q --disable-warnings --maxfail=1
+        run: pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run black, flake8, and pytest on Python 3.10
- cache pip dependencies for faster runs

## Testing
- `black --check .` *(fails: would reformat files)*
- `flake8 .` *(fails: command not found)*
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1e6de31d08329aa7873e647ad75df