### PR TITLE
Add schema freeze test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
             mypy btcmi || echo "mypy warnings"
           fi
 
+      - name: Run schema freeze test
+        env:
+          PYTHONPATH: .
+        run: pytest -q --disable-warnings --maxfail=1 tests/test_schema_freeze.py
+
       - name: Run tests with pytest
         env:
           PYTHONPATH: .

--- a/tests/test_schema_freeze.py
+++ b/tests/test_schema_freeze.py
@@ -1,0 +1,20 @@
+import hashlib
+from pathlib import Path
+
+
+def sha256sum(path: Path) -> str:
+    """Return SHA256 hex digest for file at path."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_schema_freeze():
+    repo_root = Path(__file__).resolve().parent.parent
+    expected_hashes = {
+        "input_schema.json": "c587073c2baebf4317fd80d4e9a059244313ad283eba4abbbfc523d55a346ddf",
+        "output_schema.json": "ad2a0f1f7933df91faf09eb76ca7bbf566913c7a200694ca4b03b9e0effdbac3",
+    }
+    for filename, expected in expected_hashes.items():
+        file_hash = sha256sum(repo_root / filename)
+        assert (
+            file_hash == expected
+        ), f"{filename} hash changed: {file_hash} != {expected}"


### PR DESCRIPTION
## Summary
- add test to assert SHA256 hashes for input/output schemas
- run schema freeze test in CI

## Testing
- `pytest tests/test_schema_freeze.py -q --disable-warnings --maxfail=1`
- `PYTHONPATH=. pytest -q --disable-warnings --maxfail=1`
- `pre-commit run --files tests/test_schema_freeze.py .github/workflows/ci.yml` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2011455b08329bed89951fde7060c