### PR TITLE
Add property-based tests for engines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ license = {text="MIT"}
 dev = [
     "black>=24.4.2",
     "ruff>=0.6.4",
+    "hypothesis>=6.100.0",
 ]
 [project.scripts]
 btcmi = "cli.btcmi:main"

--- a/tests/property/test_engine_v1.py
+++ b/tests/property/test_engine_v1.py
@@ -1,0 +1,65 @@
+import math
+from hypothesis import given, strategies as st
+from btcmi.engine_v1 import (
+    normalize,
+    base_signal,
+    nagr_score,
+    combine,
+    SCENARIO_WEIGHTS,
+    NORM_SCALE,
+)
+
+# Strategy for feature dictionaries
+feature_names = list(NORM_SCALE.keys())
+
+
+@given(
+    st.dictionaries(
+        st.sampled_from(feature_names),
+        st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False),
+        min_size=1,
+    )
+)
+def test_normalize_bounds(features):
+    norm = normalize(features)
+    assert norm
+    assert all(-1.0 <= v <= 1.0 for v in norm.values())
+
+
+@given(
+    st.sampled_from(list(SCENARIO_WEIGHTS.keys())),
+    st.dictionaries(
+        st.sampled_from(feature_names),
+        st.floats(-1, 1, allow_nan=False, allow_infinity=False),
+        min_size=1,
+    ),
+)
+def test_base_signal_weights_and_bounds(scenario, norm):
+    score, weights, _ = base_signal(scenario, norm)
+    assert -1.0 <= score <= 1.0
+    assert math.isclose(sum(abs(w) for w in weights.values()), 1.0)
+
+
+@given(
+    st.floats(-10, 10, allow_nan=False, allow_infinity=False),
+    st.floats(-10, 10, allow_nan=False, allow_infinity=False),
+)
+def test_combine_clips(base, nagr):
+    val = combine(base, nagr)
+    assert -1.0 <= val <= 1.0
+
+
+@given(
+    st.lists(
+        st.fixed_dictionaries(
+            {
+                "weight": st.floats(-10, 10, allow_nan=False, allow_infinity=False),
+                "score": st.floats(-10, 10, allow_nan=False, allow_infinity=False),
+            }
+        ),
+        max_size=10,
+    )
+)
+def test_nagr_score_bounds(nodes):
+    val = nagr_score(nodes)
+    assert -1.0 <= val <= 1.0

--- a/tests/property/test_engine_v2.py
+++ b/tests/property/test_engine_v2.py
@@ -1,0 +1,120 @@
+import math
+from hypothesis import given, strategies as st
+from btcmi.engine_v2 import (
+    tanh_norm,
+    normalize_layer,
+    router_weights,
+    combine_levels,
+    layer_equal_weights,
+    level_signal,
+    nagr,
+    SCALES,
+)
+
+layers = list(SCALES.keys())
+
+
+@st.composite
+def layer_and_features(draw):
+    layer = draw(st.sampled_from(layers))
+    feats = draw(
+        st.dictionaries(
+            st.sampled_from(list(SCALES[layer].keys())),
+            st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False),
+            min_size=1,
+        )
+    )
+    return layer, feats
+
+
+@given(
+    st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False),
+    st.floats(0.1, 1e6, allow_nan=False, allow_infinity=False),
+)
+def test_tanh_norm_bounds(x, s):
+    val = tanh_norm(x, s)
+    assert -1.0 <= val <= 1.0
+
+
+@given(layer_and_features())
+def test_normalize_layer_bounds(data):
+    layer, feats = data
+    norm = normalize_layer(feats, SCALES[layer])
+    assert norm
+    assert all(-1.0 <= v <= 1.0 for v in norm.values())
+
+
+@given(
+    st.dictionaries(
+        st.text(min_size=1),
+        st.floats(-1, 1, allow_nan=False, allow_infinity=False),
+        min_size=1,
+    )
+)
+def test_layer_equal_weights_sum(norm):
+    weights = layer_equal_weights(norm)
+    assert weights
+    assert math.isclose(sum(weights.values()), 1.0)
+
+
+@given(st.floats(0, 1, allow_nan=False, allow_infinity=False))
+def test_router_weights_sum(vol):
+    _, weights = router_weights(vol)
+    assert math.isclose(sum(weights.values()), 1.0)
+
+
+@given(
+    st.lists(
+        st.fixed_dictionaries(
+            {
+                "weight": st.floats(-10, 10, allow_nan=False, allow_infinity=False),
+                "score": st.floats(-10, 10, allow_nan=False, allow_infinity=False),
+            }
+        ),
+        max_size=10,
+    )
+)
+def test_nagr_bounds(nodes):
+    val = nagr(nodes)
+    assert -1.0 <= val <= 1.0
+
+
+@given(
+    st.floats(0, 1, allow_nan=False, allow_infinity=False),
+    st.floats(-10, 10, allow_nan=False, allow_infinity=False),
+    st.floats(-10, 10, allow_nan=False, allow_infinity=False),
+    st.floats(-10, 10, allow_nan=False, allow_infinity=False),
+)
+def test_combine_levels_clips(vol, L1, L2, L3):
+    _, weights = router_weights(vol)
+    assert math.isclose(sum(weights.values()), 1.0)
+    score = combine_levels(L1, L2, L3, weights)
+    assert -1.0 <= score <= 1.0
+
+
+@st.composite
+def level_input(draw):
+    layer, feats = draw(layer_and_features())
+    norm = normalize_layer(feats, SCALES[layer])
+    weights = layer_equal_weights(norm)
+    nodes = draw(
+        st.lists(
+            st.fixed_dictionaries(
+                {
+                    "weight": st.floats(-10, 10, allow_nan=False, allow_infinity=False),
+                    "score": st.floats(-10, 10, allow_nan=False, allow_infinity=False),
+                }
+            ),
+            max_size=10,
+        )
+    )
+    return norm, weights, nodes
+
+
+@given(level_input())
+def test_level_signal_bounds(data):
+    norm, weights, nodes = data
+    score, _ = level_signal(norm, weights, nodes)
+    assert -1.0 <= score <= 1.0
+    if weights:
+        assert math.isclose(sum(weights.values()), 1.0)


### PR DESCRIPTION
## Summary
- add Hypothesis as a dev dependency
- cover engine v1 and v2 with property-based tests for normalization bounds, weight sums, and score clipping

## Testing
- `pip install -e .[dev]` *(failed: Could not find a version that satisfies the requirement setuptools>=68)*
- `pytest tests/property/test_engine_v1.py tests/property/test_engine_v2.py` *(failed: ModuleNotFoundError: No module named 'hypothesis`)*

------
https://chatgpt.com/codex/tasks/task_e_68b2026834e48329bbf8d1a6d3f7dd94