### PR TITLE
Add API snapshot tests

### DIFF
--- a/docs/SNAPSHOTS.md
+++ b/docs/SNAPSHOTS.md
@@ -1,0 +1,13 @@
+# Snapshot Updates
+
+The API regression tests compare responses against snapshot files in `tests/golden`.
+If you intentionally change the API output, regenerate the snapshots with:
+
+```bash
+UPDATE_SNAPSHOTS=1 pytest tests/test_api_snapshots.py
+```
+
+The updated files will be written to:
+
+- `tests/golden/api_run_v1.golden.json`
+- `tests/golden/api_run_v2.golden.json`

--- a/tests/golden/api_run_v1.golden.json
+++ b/tests/golden/api_run_v1.golden.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "2.0.0",
+  "lineage": {
+    "request_id": "1234567890abcdef1234567890abcdef"
+  },
+  "asof": "2025-01-01T00:00:00Z",
+  "summary": {
+    "scenario": "intraday",
+    "window": "1h",
+    "overall_signal": 0.312587,
+    "confidence": 1.0,
+    "router_path": "intraday/v1",
+    "nagr_score": 0.16,
+    "advisories": []
+  },
+  "details": {
+    "normalized_features": {
+      "price_change_pct": 0.379949,
+      "volume_change_pct": 0.604368,
+      "funding_rate_bps": 0.379949,
+      "oi_change_pct": 0.53705,
+      "onchain_active_addrs_change_pct": 0.244919
+    },
+    "weights": {
+      "price_change_pct": 0.35,
+      "volume_change_pct": 0.25,
+      "funding_rate_bps": -0.1,
+      "oi_change_pct": 0.2,
+      "onchain_active_addrs_change_pct": 0.1
+    },
+    "contributions": {
+      "price_change_pct": 0.132982,
+      "volume_change_pct": 0.151092,
+      "funding_rate_bps": -0.037995,
+      "oi_change_pct": 0.10741,
+      "onchain_active_addrs_change_pct": 0.024492
+    },
+    "constraints_applied": false,
+    "diagnostics": {
+      "completeness": 1.0,
+      "notes": []
+    }
+  }
+}

--- a/tests/golden/api_run_v2.golden.json
+++ b/tests/golden/api_run_v2.golden.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "2.0.0",
+  "lineage": {
+    "request_id": "1234567890abcdef1234567890abcdef"
+  },
+  "asof": "2025-01-01T00:00:00Z",
+  "summary": {
+    "scenario": "intraday",
+    "window": "1h",
+    "overall_signal": 0.238605,
+    "confidence": 1.0,
+    "router_path": "intraday/v2.fractal",
+    "nagr_score": 0.0,
+    "advisories": [],
+    "overall_signal_L1": 0.412263,
+    "overall_signal_L2": 0.189658,
+    "overall_signal_L3": 0.170504,
+    "level_weights": {
+      "L1": 0.25,
+      "L2": 0.4,
+      "L3": 0.35
+    }
+  },
+  "details": {
+    "normalized_micro": {
+      "price_change_pct": 0.379949,
+      "volume_change_pct": 0.604368,
+      "funding_rate_bps": 0.379949,
+      "oi_change_pct": 0.53705
+    },
+    "normalized_mezo": {
+      "oi_term_structure_slope": 0.235496,
+      "funding_premium_spread": 0.158649
+    },
+    "normalized_macro": {
+      "active_addrs_trend": 0.197375,
+      "macro_regime_score": 0.148885
+    },
+    "router_regime": "mid",
+    "diagnostics": {
+      "completeness": 1.0,
+      "notes": []
+    }
+  }
+}

--- a/tests/test_api_snapshots.py
+++ b/tests/test_api_snapshots.py
@@ -1,0 +1,38 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+R = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(R))
+
+from fastapi.testclient import TestClient
+
+from api.app import app, RUNNERS
+from cli.btcmi import run_v1, run_v2
+
+def _load_example(name: str) -> dict:
+    return json.loads((R / "examples" / f"{name}.json").read_text())
+
+def _prepare_client(monkeypatch) -> TestClient:
+    monkeypatch.setitem(RUNNERS, "v1", lambda p, _t, o: run_v1(p, "2025-01-01T00:00:00Z", o))
+    monkeypatch.setitem(RUNNERS, "v2.fractal", lambda p, _t, o: run_v2(p, "2025-01-01T00:00:00Z", o))
+    return TestClient(app)
+
+def _assert_snapshot(client: TestClient, payload: dict, golden: Path) -> None:
+    resp = client.post("/run", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    if os.getenv("UPDATE_SNAPSHOTS"):
+        golden.write_text(json.dumps(data, indent=2))
+    assert data == json.loads(golden.read_text())
+
+def test_run_v1_snapshot(monkeypatch):
+    client = _prepare_client(monkeypatch)
+    payload = _load_example("intraday")
+    _assert_snapshot(client, payload, R / "tests/golden/api_run_v1.golden.json")
+
+def test_run_v2_snapshot(monkeypatch):
+    client = _prepare_client(monkeypatch)
+    payload = _load_example("intraday_fractal")
+    _assert_snapshot(client, payload, R / "tests/golden/api_run_v2.golden.json")


### PR DESCRIPTION
## Summary
- add API snapshot tests for /run endpoint in v1 and v2.fractal modes
- store responses in golden files and document how to refresh snapshots

## Testing
- `pytest tests/test_api_snapshots.py`

------
https://chatgpt.com/codex/tasks/task_e_68b203ff1b588329a92c92585e20302b