### PR TITLE
refactor: move runner logic into package

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, HTTPException, Response
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest
 
 from btcmi.schema_util import validate_json
-from cli.btcmi import run_v1, run_v2
+from btcmi.runner import run_v1, run_v2
 
 app = FastAPI()
 

--- a/btcmi/runner.py
+++ b/btcmi/runner.py
@@ -1,0 +1,132 @@
+"""Runner functions for BTCMI engines.
+
+This module exposes high-level helpers used by the CLI and API to execute
+either the v1 or v2 (fractal) engine. The functions accept input data and
+produce an output JSON document written to ``out_path``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Dict
+
+from btcmi import engine_v1 as v1
+from btcmi import engine_v2 as v2
+
+# Scenarios supported by both engines.
+ALLOWED_SCENARIOS = frozenset(v1.SCENARIO_WEIGHTS.keys())
+
+
+def run_v1(data, fixed_ts, out_path):
+    """Execute the v1 engine and write the result to ``out_path``."""
+
+    scenario = data.get("scenario")
+    if scenario is None:
+        raise ValueError("'scenario' field is required")
+    if scenario not in ALLOWED_SCENARIOS:
+        raise ValueError("'scenario' must be one of: " + ", ".join(sorted(ALLOWED_SCENARIOS)))
+    window = data.get("window")
+    if window is None:
+        raise ValueError("'window' field is required")
+    feats: Dict[str, float] = data.get("features", {})
+    norm = v1.normalize(feats)
+    base, weights, contrib = v1.base_signal(scenario, norm)
+    ng = v1.nagr_score(data.get("nagr_nodes", []))
+    overall = v1.combine(base, ng)
+    comp = v1.completeness(feats)
+    conf = round(0.5 + 0.5 * comp, 3)
+    notes: list[str] = []
+    constraints = False
+    if comp < 0.6:
+        notes.append("low_feature_completeness")
+    asof = fixed_ts or dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    out = {
+        "schema_version": data.get("schema_version", "2.0.0"),
+        "lineage": data.get("lineage", {}),
+        "asof": asof,
+        "summary": {
+            "scenario": scenario,
+            "window": window,
+            "overall_signal": round(overall, 6),
+            "confidence": conf,
+            "router_path": f"{scenario}/v1",
+            "nagr_score": round(ng, 6),
+            "advisories": notes,
+        },
+        "details": {
+            "normalized_features": {k: round(v, 6) for k, v in norm.items()},
+            "weights": v1.SCENARIO_WEIGHTS[scenario],
+            "contributions": {k: round(v, 6) for k, v in contrib.items()},
+            "constraints_applied": constraints,
+            "diagnostics": {"completeness": round(comp, 3), "notes": notes},
+        },
+    }
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(out_path).write_text(json.dumps(out, indent=2), encoding="utf-8")
+    return out
+
+
+def run_v2(data, fixed_ts, out_path):
+    """Execute the v2 fractal engine and write the result to ``out_path``."""
+
+    scenario = data.get("scenario")
+    if scenario is None:
+        raise ValueError("'scenario' field is required")
+    if scenario not in ALLOWED_SCENARIOS:
+        raise ValueError("'scenario' must be one of: " + ", ".join(sorted(ALLOWED_SCENARIOS)))
+    window = data.get("window")
+    if window is None:
+        raise ValueError("'window' field is required")
+    f1 = data.get("features_micro", {})
+    f2 = data.get("features_mezo", {})
+    f3 = data.get("features_macro", {})
+    vol_pctl = float(data.get("vol_regime_pctl", 0.5))
+    n1 = v2.normalize_layer(f1, v2.SCALES["L1"])
+    n2 = v2.normalize_layer(f2, v2.SCALES["L2"])
+    n3 = v2.normalize_layer(f3, v2.SCALES["L3"])
+    w1 = v2.layer_equal_weights(n1)
+    w2 = v2.layer_equal_weights(n2)
+    w3 = v2.layer_equal_weights(n3)
+    s1, _ = v2.level_signal(n1, w1, data.get("nagr_nodes", []))
+    s2, _ = v2.level_signal(n2, w2, data.get("nagr_nodes", []))
+    s3, _ = v2.level_signal(n3, w3, data.get("nagr_nodes", []))
+    regime, alphas = v2.router_weights(vol_pctl)
+    overall = v2.combine_levels(s1, s2, s3, alphas)
+    coverage = sum(len(x) > 0 for x in [n1, n2, n3]) / 3.0
+    conf = round(0.5 + 0.5 * min(coverage, 1.0), 3)
+    notes: list[str] = []
+    asof = fixed_ts or dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    out = {
+        "schema_version": data.get("schema_version", "2.0.0"),
+        "lineage": data.get("lineage", {}),
+        "asof": asof,
+        "summary": {
+            "scenario": scenario,
+            "window": window,
+            "overall_signal": round(overall, 6),
+            "confidence": conf,
+            "router_path": f"{scenario}/v2.fractal",
+            "nagr_score": 0.0,
+            "advisories": notes,
+            "overall_signal_L1": round(s1, 6),
+            "overall_signal_L2": round(s2, 6),
+            "overall_signal_L3": round(s3, 6),
+            "level_weights": alphas,
+        },
+        "details": {
+            "normalized_micro": {k: round(v, 6) for k, v in n1.items()},
+            "normalized_mezo": {k: round(v, 6) for k, v in n2.items()},
+            "normalized_macro": {k: round(v, 6) for k, v in n3.items()},
+            "router_regime": regime,
+            "diagnostics": {"completeness": round(coverage, 3), "notes": notes},
+        },
+    }
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(out_path).write_text(json.dumps(out, indent=2), encoding="utf-8")
+    return out
+
+
+__all__ = ["run_v1", "run_v2", "ALLOWED_SCENARIOS"]
+

--- a/cli/btcmi.py
+++ b/cli/btcmi.py
@@ -1,74 +1,18 @@
 #!/usr/bin/env python3
 from __future__ import annotations
+
 import argparse
-import json
-import datetime as dt
-import sys
 import logging
 from pathlib import Path
-from typing import Dict
-# Ensure local package importable
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from btcmi.logging_cfg import configure_logging, new_run_id
+from btcmi.runner import run_v1, run_v2
 from btcmi.schema_util import load_json, validate_json
-from btcmi import engine_v1 as v1
-from btcmi import engine_v2 as v2
 
-ALLOWED_SCENARIOS = frozenset(v1.SCENARIO_WEIGHTS.keys())
-
-def run_v1(data, fixed_ts, out_path):
-    scenario=data.get("scenario")
-    if scenario is None:
-        raise ValueError("'scenario' field is required")
-    if scenario not in ALLOWED_SCENARIOS:
-        raise ValueError("'scenario' must be one of: "+", ".join(sorted(ALLOWED_SCENARIOS)))
-    window=data.get("window")
-    if window is None:
-        raise ValueError("'window' field is required")
-    feats:Dict[str,float]=data.get("features",{})
-    norm=v1.normalize(feats); base,weights,contrib=v1.base_signal(scenario,norm); ng=v1.nagr_score(data.get("nagr_nodes",[])); overall=v1.combine(base,ng)
-    comp=v1.completeness(feats)
-    conf=round(0.5+0.5*comp,3); notes=[]; constraints=False
-    if comp<0.6: notes.append("low_feature_completeness")
-    asof=fixed_ts or dt.datetime.utcnow().replace(microsecond=0).isoformat()+"Z"
-    out={"schema_version":data.get("schema_version","2.0.0"),
-         "lineage":data.get("lineage",{}),
-         "asof":asof,
-         "summary":{"scenario":scenario,"window":window,"overall_signal":round(overall,6),"confidence":conf,"router_path":f"{scenario}/v1","nagr_score":round(ng,6),"advisories":notes},
-         "details":{"normalized_features":{k:round(v,6) for k,v in norm.items()},"weights":v1.SCENARIO_WEIGHTS[scenario],"contributions":{k:round(v,6) for k,v in contrib.items()},"constraints_applied":constraints,"diagnostics":{"completeness":round(comp,3),"notes":notes}}}
-    Path(out_path).parent.mkdir(parents=True, exist_ok=True); Path(out_path).write_text(json.dumps(out, indent=2), encoding="utf-8")
-    return out
-
-def run_v2(data, fixed_ts, out_path):
-    scenario=data.get("scenario")
-    if scenario is None:
-        raise ValueError("'scenario' field is required")
-    if scenario not in ALLOWED_SCENARIOS:
-        raise ValueError("'scenario' must be one of: "+", ".join(sorted(ALLOWED_SCENARIOS)))
-    window=data.get("window")
-    if window is None:
-        raise ValueError("'window' field is required")
-    f1=data.get("features_micro",{}); f2=data.get("features_mezo",{}); f3=data.get("features_macro",{})
-    vol_pctl=float(data.get("vol_regime_pctl",0.5))
-    n1=v2.normalize_layer(f1, v2.SCALES["L1"]); n2=v2.normalize_layer(f2, v2.SCALES["L2"]); n3=v2.normalize_layer(f3, v2.SCALES["L3"])
-    w1=v2.layer_equal_weights(n1); w2=v2.layer_equal_weights(n2); w3=v2.layer_equal_weights(n3)
-    s1,_=v2.level_signal(n1,w1,data.get("nagr_nodes",[])); s2,_=v2.level_signal(n2,w2,data.get("nagr_nodes",[])); s3,_=v2.level_signal(n3,w3,data.get("nagr_nodes",[]))
-    regime, alphas = v2.router_weights(vol_pctl)
-    overall=v2.combine_levels(s1,s2,s3,alphas)
-    coverage=sum(len(x)>0 for x in [n1,n2,n3])/3.0
-    conf=round(0.5+0.5*min(coverage,1.0),3); notes=[]; asof=fixed_ts or dt.datetime.utcnow().replace(microsecond=0).isoformat()+"Z"
-    out={"schema_version":data.get("schema_version","2.0.0"),
-         "lineage":data.get("lineage",{}),
-         "asof":asof,
-         "summary":{"scenario":scenario,"window":window,"overall_signal":round(overall,6),"confidence":conf,"router_path":f"{scenario}/v2.fractal","nagr_score":0.0,"advisories":notes,
-                                 "overall_signal_L1":round(s1,6),"overall_signal_L2":round(s2,6),"overall_signal_L3":round(s3,6),"level_weights":alphas},
-         "details":{"normalized_micro":{k:round(v,6) for k,v in n1.items()},"normalized_mezo":{k:round(v,6) for k,v in n2.items()},"normalized_macro":{k:round(v,6) for k,v in n3.items()},"router_regime":regime,
-                    "diagnostics":{"completeness":round(coverage,3),"notes":notes}}}
-    Path(out_path).parent.mkdir(parents=True, exist_ok=True); Path(out_path).write_text(json.dumps(out, indent=2), encoding="utf-8")
-    return out
 
 def main():
-    configure_logging(); logger=logging.getLogger(__name__)
+    configure_logging()
+    logger = logging.getLogger(__name__)
     p=argparse.ArgumentParser(prog="btcmi")
     sub=p.add_subparsers(dest="cmd", required=True)
     pr=sub.add_parser("run", help="Produce BTCMI report from input JSON")

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -2,6 +2,9 @@ import json
 from pathlib import Path
 
 import pytest
+import json
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 from prometheus_client import CONTENT_TYPE_LATEST
 from prometheus_client.parser import text_string_to_metric_families

--- a/tests/test_api_snapshots.py
+++ b/tests/test_api_snapshots.py
@@ -1,10 +1,8 @@
 import json
 import os
-import sys
 from pathlib import Path
 
 R = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(R))
 
 from fastapi.testclient import TestClient
 

--- a/tests/test_cli_required_fields.py
+++ b/tests/test_cli_required_fields.py
@@ -1,9 +1,5 @@
-import sys
-from pathlib import Path
-
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from cli.btcmi import run_v1, run_v2
 
 def test_run_v1_missing_scenario(tmp_path):

--- a/tests/test_drift_guard.py
+++ b/tests/test_drift_guard.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
-import json, subprocess
+import json
+import subprocess
 from pathlib import Path
-R=Path(__file__).resolve().parents[1]; CLI=R/"cli"/"btcmi.py"
+
+R = Path(__file__).resolve().parents[1]
+CLI = ["python3", "-m", "cli.btcmi"]
 def test_drift_guard_mid():
     out1=R/"tests/tmp/dg_v1.out.json"
-    r1=subprocess.run(["python3",str(CLI),"run","--input",str(R/"examples/intraday.json"),"--out",str(out1),"--fixed-ts","2025-01-01T00:00:00Z"])
+    r1 = subprocess.run(CLI + ["run", "--input", str(R/"examples/intraday.json"), "--out", str(out1), "--fixed-ts", "2025-01-01T00:00:00Z"])
     assert r1.returncode==0
     s1=json.loads(out1.read_text())["summary"]["overall_signal"]
     sample={"schema_version":"2.0.0","lineage":{"request_id":"1234567890abcdef1234567890abcdef"},"scenario":"intraday","window":"1h","mode":"v2.fractal","features_micro":{"price_change_pct":0.8,"volume_change_pct":35.0,"funding_rate_bps":4.0,"oi_change_pct":12.0},"features_mezo":{},"features_macro":{},"vol_regime_pctl":0.55}
     inp=R/"tests/tmp/dg_v2.in.json"; inp.write_text(json.dumps(sample), encoding="utf-8")
     out2=R/"tests/tmp/dg_v2.out.json"
-    r2=subprocess.run(["python3",str(CLI),"run","--input",str(inp),"--out",str(out2),"--fixed-ts","2025-01-01T00:00:00Z","--fractal"])
+    r2 = subprocess.run(CLI + ["run", "--input", str(inp), "--out", str(out2), "--fixed-ts", "2025-01-01T00:00:00Z", "--fractal"])
     assert r2.returncode==0
     s2=json.loads(out2.read_text())["summary"]["overall_signal"]
     assert abs(s2 - s1) <= 0.25

--- a/tests/test_golden_v1.py
+++ b/tests/test_golden_v1.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
-import json, subprocess
+import json
+import subprocess
 from pathlib import Path
-R=Path(__file__).resolve().parents[1]; CLI=R/"cli"/"btcmi.py"
+
+R = Path(__file__).resolve().parents[1]
+CLI = ["python3", "-m", "cli.btcmi"]
 def test_v1_intraday():
     out=R/"tests/tmp/intraday_v1.out.json"; gold=R/"tests/golden/intraday_v1.golden.json"
-    r=subprocess.run(["python3",str(CLI),"run","--input",str(R/"examples/intraday.json"),"--out",str(out),"--fixed-ts","2025-01-01T00:00:00Z"])
+    r = subprocess.run(CLI + ["run", "--input", str(R/"examples/intraday.json"), "--out", str(out), "--fixed-ts", "2025-01-01T00:00:00Z"])
     assert r.returncode==0
     assert json.loads(out.read_text())==json.loads(gold.read_text())

--- a/tests/test_golden_v2.py
+++ b/tests/test_golden_v2.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-import json, subprocess
+import json
+import subprocess
 from pathlib import Path
-R=Path(__file__).resolve().parents[1]; CLI=R/"cli"/"btcmi.py"
+
+R = Path(__file__).resolve().parents[1]
+CLI = ["python3", "-m", "cli.btcmi"]
 def _cmp(nm):
     out=R/f"tests/tmp/{nm}.out.json"; gold=R/f"tests/golden/{nm}.golden.json"
-    r=subprocess.run(["python3",str(CLI),"run","--input",str(R/f"examples/{nm}.json"),"--out",str(out),"--fixed-ts","2025-01-01T00:00:00Z","--fractal"])
+    r = subprocess.run(CLI + ["run", "--input", str(R/f"examples/{nm}.json"), "--out", str(out), "--fixed-ts", "2025-01-01T00:00:00Z", "--fractal"])
     assert r.returncode==0
     assert json.loads(out.read_text())==json.loads(gold.read_text())
 def test_intraday_fractal(): _cmp("intraday_fractal")

--- a/tests/test_logging_cfg.py
+++ b/tests/test_logging_cfg.py
@@ -1,9 +1,6 @@
 import json
 import logging
-import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from btcmi.logging_cfg import configure_logging, new_run_id
 
 

--- a/tests/test_router_regime.py
+++ b/tests/test_router_regime.py
@@ -1,6 +1,3 @@
-import sys
-from pathlib import Path as _P
-sys.path.insert(0, str(_P(__file__).resolve().parents[1]))
 #!/usr/bin/env python3
 from btcmi.engine_v2 import router_weights
 def test_router_low():


### PR DESCRIPTION
## Summary
- relocate run_v1/run_v2 to btcmi.runner
- load runners from btcmi.runner in cli and API
- drop manual sys.path manipulation and call CLI as module

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b20a88f8a88329ae65f93d2550bd07