### PR TITLE
style: reorder imports in api app test

### DIFF
--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -1,10 +1,10 @@
 import json
 from pathlib import Path
 
-import pytest
 from fastapi.testclient import TestClient
 from prometheus_client import CONTENT_TYPE_LATEST
 from prometheus_client.parser import text_string_to_metric_families
+import pytest
 
 from api.app import app, RUNNERS, REQUEST_COUNTER
 


### PR DESCRIPTION
## Summary
- order imports in tests/api test file

## Testing
- `PYTHONPATH=. pytest tests/test_api_app.py`
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit, Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b29ed45904832992421580b074a704