### PR TITLE
test: import runners from package

### DIFF
--- a/btcmi/__init__.py
+++ b/btcmi/__init__.py
@@ -1,2 +1,2 @@
 __version__="1.2.1"
-__all__=["engine_v1","engine_v2","logging_cfg","schema_util","utils"]
+__all__=["engine_v1","engine_v2","logging_cfg","schema_util","utils","runner"]

--- a/btcmi/runner.py
+++ b/btcmi/runner.py
@@ -1,0 +1,9 @@
+"""Convenience runners for BTC market intelligence.
+
+These re-export the command-line run functions so they can be imported
+without relying on the CLI module path.
+"""
+
+from cli.btcmi import run_v1, run_v2
+
+__all__ = ["run_v1", "run_v2"]

--- a/tests/test_cli_required_fields.py
+++ b/tests/test_cli_required_fields.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from cli.btcmi import run_v1, run_v2
+from btcmi.runner import run_v1, run_v2
 
 def test_run_v1_missing_scenario(tmp_path):
     data = {"window": "intraday"}


### PR DESCRIPTION
## Summary
- import run_v1 and run_v2 from `btcmi.runner` in CLI tests
- expose runner helpers in `btcmi` package

## Testing
- `pytest tests/test_cli_required_fields.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b29ed88a708329888bbef31f2b2d09