### PR TITLE
chore: streamline imports in API app tests

### DIFF
--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 from prometheus_client import CONTENT_TYPE_LATEST
 from prometheus_client.parser import text_string_to_metric_families
-import pytest
 
 from api.app import app, RUNNERS, REQUEST_COUNTER
 


### PR DESCRIPTION
## Summary
- remove unused pytest import and group imports by origin

## Testing
- `PYTHONPATH=. pytest tests/test_api_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2aededfd483299c023710b37fe9f5