### PR TITLE
test: use runner helpers in API snapshots

### DIFF
--- a/tests/test_api_snapshots.py
+++ b/tests/test_api_snapshots.py
@@ -11,12 +11,14 @@ from fastapi.testclient import TestClient
 from api.app import app, RUNNERS
 from btcmi.runner import run_v1, run_v2
 
+FIXED_TS = "2025-01-01T00:00:00Z"
+
 def _load_example(name: str) -> dict:
     return json.loads((R / "examples" / f"{name}.json").read_text())
 
 def _prepare_client(monkeypatch) -> TestClient:
-    monkeypatch.setitem(RUNNERS, "v1", lambda p, _t, o: run_v1(p, "2025-01-01T00:00:00Z", o))
-    monkeypatch.setitem(RUNNERS, "v2.fractal", lambda p, _t, o: run_v2(p, "2025-01-01T00:00:00Z", o))
+    monkeypatch.setitem(RUNNERS, "v1", lambda p, _t, o: run_v1(p, FIXED_TS, o))
+    monkeypatch.setitem(RUNNERS, "v2.fractal", lambda p, _t, o: run_v2(p, FIXED_TS, o))
     return TestClient(app)
 
 def _assert_snapshot(client: TestClient, payload: dict, golden: Path) -> None:


### PR DESCRIPTION
## Summary
- factor out fixed timestamp in API snapshot tests
- use btcmi.runner helpers when monkeypatching RUNNERS

## Testing
- `pytest tests/test_api_snapshots.py`
- ⚠️ `pre-commit run --files tests/test_api_snapshots.py` (failed: command not found; pip install pre-commit blocked)


------
https://chatgpt.com/codex/tasks/task_e_68b2aee08d8c8329b78f87651c6905a3