### PR TITLE
tests: import runner functions directly

### DIFF
--- a/tests/test_cli_required_fields.py
+++ b/tests/test_cli_required_fields.py
@@ -1,10 +1,6 @@
-import sys
-from pathlib import Path
-
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from cli.btcmi import run_v1, run_v2
+from btcmi.runner import run_v1, run_v2
 
 def test_run_v1_missing_scenario(tmp_path):
     data = {"window": "intraday"}


### PR DESCRIPTION
## Summary
- import run_v1 and run_v2 from btcmi.runner in CLI required fields test

## Testing
- `python -m pytest tests/test_cli_required_fields.py`
- ⚠️ `pre-commit run --files tests/test_cli_required_fields.py` (missing pre-commit)


------
https://chatgpt.com/codex/tasks/task_e_68b2b0eccfc08329b68154502c5b0062