### PR TITLE
refactor: remove semicolon-separated statements

### DIFF
--- a/btcmi/engine_v1.py
+++ b/btcmi/engine_v1.py
@@ -8,11 +8,37 @@ from btcmi.utils import is_number
 
 FeatureMap = Dict[str, float]
 SCENARIO_WEIGHTS = {
-    "intraday": {"price_change_pct":0.35,"volume_change_pct":0.25,"funding_rate_bps":-0.10,"oi_change_pct":0.20,"onchain_active_addrs_change_pct":0.10},
-    "scalp":    {"price_change_pct":0.45,"volume_change_pct":0.30,"funding_rate_bps":-0.05,"oi_change_pct":0.15,"onchain_active_addrs_change_pct":0.05},
-    "swing":    {"price_change_pct":0.25,"volume_change_pct":0.15,"funding_rate_bps":-0.10,"oi_change_pct":0.25,"onchain_active_addrs_change_pct":0.25},
+    "intraday": {
+        "price_change_pct": 0.35,
+        "volume_change_pct": 0.25,
+        "funding_rate_bps": -0.10,
+        "oi_change_pct": 0.20,
+        "onchain_active_addrs_change_pct": 0.10,
+    },
+    "scalp": {
+        "price_change_pct": 0.45,
+        "volume_change_pct": 0.30,
+        "funding_rate_bps": -0.05,
+        "oi_change_pct": 0.15,
+        "onchain_active_addrs_change_pct": 0.05,
+    },
+    "swing": {
+        "price_change_pct": 0.25,
+        "volume_change_pct": 0.15,
+        "funding_rate_bps": -0.10,
+        "oi_change_pct": 0.25,
+        "onchain_active_addrs_change_pct": 0.25,
+    },
 }
-NORM_SCALE = {"price_change_pct":2.0,"volume_change_pct":50.0,"funding_rate_bps":10.0,"oi_change_pct":20.0,"onchain_active_addrs_change_pct":20.0}
+NORM_SCALE = {
+    "price_change_pct": 2.0,
+    "volume_change_pct": 50.0,
+    "funding_rate_bps": 10.0,
+    "oi_change_pct": 20.0,
+    "onchain_active_addrs_change_pct": 20.0,
+}
+
+
 def normalize(features: FeatureMap) -> FeatureMap:
     """Scale raw feature values using hyperbolic tangent.
 
@@ -23,7 +49,11 @@ def normalize(features: FeatureMap) -> FeatureMap:
         A feature map with each numeric value normalized to the [-1, 1] range.
 
     """
-    return {k: math.tanh(v / NORM_SCALE.get(k, 1.0)) for k, v in features.items() if is_number(v)}
+    return {
+        k: math.tanh(v / NORM_SCALE.get(k, 1.0))
+        for k, v in features.items()
+        if is_number(v)
+    }
 
 
 def completeness(features: FeatureMap) -> float:
@@ -39,6 +69,8 @@ def completeness(features: FeatureMap) -> float:
     exp = set(NORM_SCALE.keys())
     pres = {k for k, v in features.items() if k in exp and is_number(v)}
     return len(pres) / len(exp) if exp else 1.0
+
+
 def base_signal(scenario: str, norm: FeatureMap):
     """Calculate weighted signal for a trading scenario.
 
@@ -50,11 +82,19 @@ def base_signal(scenario: str, norm: FeatureMap):
         Tuple of overall score, applied weights, and individual contributions.
 
     """
-    weights = SCENARIO_WEIGHTS[scenario]; s = 0.0; den = 0.0; contrib = {}
+    weights = SCENARIO_WEIGHTS[scenario]
+    s = 0.0
+    den = 0.0
+    contrib = {}
     for k, w in weights.items():
         if k in norm:
-            c = norm[k] * w; contrib[k] = c; s += c; den += abs(w)
+            c = norm[k] * w
+            contrib[k] = c
+            s += c
+            den += abs(w)
     return (max(-1.0, min(1.0, s / den)) if den else 0.0, weights, contrib)
+
+
 def nagr_score(nodes: Any) -> float:
     """Aggregate a network graph rating score.
 
@@ -67,10 +107,16 @@ def nagr_score(nodes: Any) -> float:
     """
     if not nodes:
         return 0.0
-    num = 0.0; den = 0.0
+    num = 0.0
+    den = 0.0
     for n in nodes:
-        w = float(n.get("weight", 0.0)); sc = float(n.get("score", 0.0)); num += w * sc; den += abs(w)
+        w = float(n.get("weight", 0.0))
+        sc = float(n.get("score", 0.0))
+        num += w * sc
+        den += abs(w)
     return max(-1.0, min(1.0, num / den if den else 0.0))
+
+
 def combine(base: float, nagr: float) -> float:
     """Blend base and network scores.
 

--- a/btcmi/engine_v2.py
+++ b/btcmi/engine_v2.py
@@ -5,6 +5,7 @@ from typing import Dict, List
 import math
 from btcmi.utils import is_number
 
+
 def tanh_norm(x: float, s: float) -> float:
     """Normalize a value using hyperbolic tangent scaling.
 
@@ -18,7 +19,10 @@ def tanh_norm(x: float, s: float) -> float:
     """
     return math.tanh(x / s) if s else 0.0
 
-def normalize_layer(feats: Dict[str, float], scales: Dict[str, float]) -> Dict[str, float]:
+
+def normalize_layer(
+    feats: Dict[str, float], scales: Dict[str, float]
+) -> Dict[str, float]:
     """Apply normalization to a layer's feature set.
 
     Args:
@@ -29,7 +33,10 @@ def normalize_layer(feats: Dict[str, float], scales: Dict[str, float]) -> Dict[s
         Dictionary of normalized feature values.
 
     """
-    return {k: tanh_norm(v, scales.get(k, 1.0)) for k, v in feats.items() if is_number(v)}
+    return {
+        k: tanh_norm(v, scales.get(k, 1.0)) for k, v in feats.items() if is_number(v)
+    }
+
 
 def linear_score(norm: Dict[str, float], weights: Dict[str, float]):
     """Compute weighted linear score for normalized features.
@@ -42,12 +49,18 @@ def linear_score(norm: Dict[str, float], weights: Dict[str, float]):
         Tuple of overall score and per-feature contributions.
 
     """
-    s = 0.0; den = 0.0; contrib = {}
+    s = 0.0
+    den = 0.0
+    contrib = {}
     for k, w in weights.items():
         if k in norm:
-            c = norm[k] * w; contrib[k] = c; s += c; den += abs(w)
+            c = norm[k] * w
+            contrib[k] = c
+            s += c
+            den += abs(w)
     score = max(-1.0, min(1.0, s / den)) if den else 0.0
     return score, contrib
+
 
 def nagr(nodes: List[dict]) -> float:
     """Aggregate network graph ratings.
@@ -65,6 +78,7 @@ def nagr(nodes: List[dict]) -> float:
     den = sum(abs(float(n.get("weight", 0.0))) for n in nodes) or 1.0
     return max(-1.0, min(1.0, num / den))
 
+
 def level_signal(norm, weights, nagr_nodes):
     """Blend linear feature score with network rating for one level.
 
@@ -80,6 +94,7 @@ def level_signal(norm, weights, nagr_nodes):
     base, contrib = linear_score(norm, weights)
     return 0.8 * base + 0.2 * nagr(nagr_nodes), contrib
 
+
 def router_weights(vol_pctl: float):
     """Select level weights based on volume percentile.
 
@@ -90,9 +105,12 @@ def router_weights(vol_pctl: float):
         A tuple of descriptor string and weight mapping for levels.
 
     """
-    if vol_pctl < 0.2:   return "low", {"L1":0.15, "L2":0.35, "L3":0.50}
-    if vol_pctl < 0.6:   return "mid", {"L1":0.25, "L2":0.40, "L3":0.35}
-    return "high", {"L1":0.40, "L2":0.40, "L3":0.20}
+    if vol_pctl < 0.2:
+        return "low", {"L1": 0.15, "L2": 0.35, "L3": 0.50}
+    if vol_pctl < 0.6:
+        return "mid", {"L1": 0.25, "L2": 0.40, "L3": 0.35}
+    return "high", {"L1": 0.40, "L2": 0.40, "L3": 0.20}
+
 
 def combine_levels(L1: float, L2: float, L3: float, w):
     """Merge signals from all levels using provided weights.
@@ -110,11 +128,29 @@ def combine_levels(L1: float, L2: float, L3: float, w):
     s = w["L1"] * L1 + w["L2"] * L2 + w["L3"] * L3
     return max(-1.0, min(1.0, s))
 
+
 SCALES = {
-  "L1": {"price_change_pct":2.0,"volume_change_pct":50.0,"funding_rate_bps":10.0,"oi_change_pct":20.0,"micro_liquidity_gaps":5.0},
-  "L2": {"oi_term_structure_slope":0.5,"funding_premium_spread":0.5,"net_positioning_index":0.5,"liquidation_heatmap_entropy":1.0},
-  "L3": {"hashrate_trend":0.5,"active_addrs_trend":0.5,"supply_in_profit_pct":0.5,"macro_regime_score":1.0}
+    "L1": {
+        "price_change_pct": 2.0,
+        "volume_change_pct": 50.0,
+        "funding_rate_bps": 10.0,
+        "oi_change_pct": 20.0,
+        "micro_liquidity_gaps": 5.0,
+    },
+    "L2": {
+        "oi_term_structure_slope": 0.5,
+        "funding_premium_spread": 0.5,
+        "net_positioning_index": 0.5,
+        "liquidation_heatmap_entropy": 1.0,
+    },
+    "L3": {
+        "hashrate_trend": 0.5,
+        "active_addrs_trend": 0.5,
+        "supply_in_profit_pct": 0.5,
+        "macro_regime_score": 1.0,
+    },
 }
+
 
 def layer_equal_weights(norm: Dict[str, float]) -> Dict[str, float]:
     """Generate equal weights for a layer's features.
@@ -128,5 +164,6 @@ def layer_equal_weights(norm: Dict[str, float]) -> Dict[str, float]:
     """
     if not norm:
         return {}
-    n = len(norm); w = 1.0 / n
+    n = len(norm)
+    w = 1.0 / n
     return {k: w for k in norm.keys()}

--- a/ops/metrics/exporter.py
+++ b/ops/metrics/exporter.py
@@ -1,13 +1,32 @@
 #!/usr/bin/env python3
 # Minimal exporter placeholder; integrate with CLI output in production.
 from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
 class H(BaseHTTPRequestHandler):
-  def do_GET(self):
-    if self.path!="/metrics": self.send_response(404); self.end_headers(); return
-    body="\n".join([
-      "# TYPE btcmi_confidence gauge","btcmi_confidence 0.9",
-      "# TYPE btcmi_regime_vol_pctl gauge","btcmi_regime_vol_pctl 0.55"
-    ]).encode("utf-8")
-    self.send_response(200); self.send_header("Content-Type","text/plain; version=0.0.4"); self.send_header("Content-Length",str(len(body))); self.end_headers(); self.wfile.write(body)
-def main(): HTTPServer(("0.0.0.0",9101),H).serve_forever()
-if __name__=="__main__": main()
+    def do_GET(self):
+        if self.path != "/metrics":
+            self.send_response(404)
+            self.end_headers()
+            return
+        body = "\n".join(
+            [
+                "# TYPE btcmi_confidence gauge",
+                "btcmi_confidence 0.9",
+                "# TYPE btcmi_regime_vol_pctl gauge",
+                "btcmi_regime_vol_pctl 0.55",
+            ]
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main():
+    HTTPServer(("0.0.0.0", 9101), H).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_checksums.py
+++ b/scripts/verify_checksums.py
@@ -1,25 +1,37 @@
 #!/usr/bin/env python3
-import hashlib, sys
+import hashlib
+import sys
 from pathlib import Path
+
 ROOT = Path(__file__).resolve().parents[1]
 checks = ROOT / "CHECKSUMS.SHA256"
+
+
 def sha256(p: Path) -> str:
-    h=hashlib.sha256()
-    with open(p,"rb") as f:
+    h = hashlib.sha256()
+    with open(p, "rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
 if not checks.exists():
-    print("No CHECKSUMS.SHA256 found; skipping", file=sys.stderr); sys.exit(0)
-bad=False
+    print("No CHECKSUMS.SHA256 found; skipping", file=sys.stderr)
+    sys.exit(0)
+
+bad = False
 for line in checks.read_text().splitlines():
-    if not line.strip(): continue
+    if not line.strip():
+        continue
     want, rel = line.split(maxsplit=1)
     p = ROOT / rel.strip()
     if not p.exists():
-        print(f"MISSING {rel}", file=sys.stderr); bad=True; continue
+        print(f"MISSING {rel}", file=sys.stderr)
+        bad = True
+        continue
     got = sha256(p)
     if got != want:
-        print(f"SHA MISMATCH {rel}", file=sys.stderr); bad=True
+        print(f"SHA MISMATCH {rel}", file=sys.stderr)
+        bad = True
 print("CHECKSUMS OK" if not bad else "CHECKSUMS FAIL")
 sys.exit(2 if bad else 0)


### PR DESCRIPTION
## Summary
- expand HTTP metrics exporter into multi-line statements
- split checksum verification into one statement per line
- refactor engine v1 and v2 helpers to avoid semicolon-separated statements

## Testing
- `python -m black ops/metrics/exporter.py scripts/verify_checksums.py btcmi/engine_v1.py btcmi/engine_v2.py`
- `python -m ruff check ops/metrics/exporter.py scripts/verify_checksums.py btcmi/engine_v1.py btcmi/engine_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2aee26750832996d09b863339cbd9