### PR TITLE
refactor: split chained statements in tests

### DIFF
--- a/tests/test_drift_guard.py
+++ b/tests/test_drift_guard.py
@@ -1,16 +1,62 @@
 #!/usr/bin/env python3
-import json, subprocess
+import json
+import subprocess
 from pathlib import Path
-R=Path(__file__).resolve().parents[1]; CLI=R/"cli"/"btcmi.py"
+
+R = Path(__file__).resolve().parents[1]
+CLI = R / "cli" / "btcmi.py"
+
+
 def test_drift_guard_mid():
-    out1=R/"tests/tmp/dg_v1.out.json"
-    r1=subprocess.run(["python3",str(CLI),"run","--input",str(R/"examples/intraday.json"),"--out",str(out1),"--fixed-ts","2025-01-01T00:00:00Z"])
-    assert r1.returncode==0
-    s1=json.loads(out1.read_text())["summary"]["overall_signal"]
-    sample={"schema_version":"2.0.0","lineage":{"request_id":"1234567890abcdef1234567890abcdef"},"scenario":"intraday","window":"1h","mode":"v2.fractal","features_micro":{"price_change_pct":0.8,"volume_change_pct":35.0,"funding_rate_bps":4.0,"oi_change_pct":12.0},"features_mezo":{},"features_macro":{},"vol_regime_pctl":0.55}
-    inp=R/"tests/tmp/dg_v2.in.json"; inp.write_text(json.dumps(sample), encoding="utf-8")
-    out2=R/"tests/tmp/dg_v2.out.json"
-    r2=subprocess.run(["python3",str(CLI),"run","--input",str(inp),"--out",str(out2),"--fixed-ts","2025-01-01T00:00:00Z","--fractal"])
-    assert r2.returncode==0
-    s2=json.loads(out2.read_text())["summary"]["overall_signal"]
+    out1 = R / "tests/tmp/dg_v1.out.json"
+    r1 = subprocess.run(
+        [
+            "python3",
+            str(CLI),
+            "run",
+            "--input",
+            str(R / "examples/intraday.json"),
+            "--out",
+            str(out1),
+            "--fixed-ts",
+            "2025-01-01T00:00:00Z",
+        ]
+    )
+    assert r1.returncode == 0
+    s1 = json.loads(out1.read_text())["summary"]["overall_signal"]
+    sample = {
+        "schema_version": "2.0.0",
+        "lineage": {"request_id": "1234567890abcdef1234567890abcdef"},
+        "scenario": "intraday",
+        "window": "1h",
+        "mode": "v2.fractal",
+        "features_micro": {
+            "price_change_pct": 0.8,
+            "volume_change_pct": 35.0,
+            "funding_rate_bps": 4.0,
+            "oi_change_pct": 12.0,
+        },
+        "features_mezo": {},
+        "features_macro": {},
+        "vol_regime_pctl": 0.55,
+    }
+    inp = R / "tests/tmp/dg_v2.in.json"
+    inp.write_text(json.dumps(sample), encoding="utf-8")
+    out2 = R / "tests/tmp/dg_v2.out.json"
+    r2 = subprocess.run(
+        [
+            "python3",
+            str(CLI),
+            "run",
+            "--input",
+            str(inp),
+            "--out",
+            str(out2),
+            "--fixed-ts",
+            "2025-01-01T00:00:00Z",
+            "--fractal",
+        ]
+    )
+    assert r2.returncode == 0
+    s2 = json.loads(out2.read_text())["summary"]["overall_signal"]
     assert abs(s2 - s1) <= 0.25

--- a/tests/test_golden_v1.py
+++ b/tests/test_golden_v1.py
@@ -1,9 +1,27 @@
 #!/usr/bin/env python3
-import json, subprocess
+import json
+import subprocess
 from pathlib import Path
-R=Path(__file__).resolve().parents[1]; CLI=R/"cli"/"btcmi.py"
+
+R = Path(__file__).resolve().parents[1]
+CLI = R / "cli" / "btcmi.py"
+
+
 def test_v1_intraday():
-    out=R/"tests/tmp/intraday_v1.out.json"; gold=R/"tests/golden/intraday_v1.golden.json"
-    r=subprocess.run(["python3",str(CLI),"run","--input",str(R/"examples/intraday.json"),"--out",str(out),"--fixed-ts","2025-01-01T00:00:00Z"])
-    assert r.returncode==0
-    assert json.loads(out.read_text())==json.loads(gold.read_text())
+    out = R / "tests/tmp/intraday_v1.out.json"
+    gold = R / "tests/golden/intraday_v1.golden.json"
+    r = subprocess.run(
+        [
+            "python3",
+            str(CLI),
+            "run",
+            "--input",
+            str(R / "examples/intraday.json"),
+            "--out",
+            str(out),
+            "--fixed-ts",
+            "2025-01-01T00:00:00Z",
+        ]
+    )
+    assert r.returncode == 0
+    assert json.loads(out.read_text()) == json.loads(gold.read_text())

--- a/tests/test_golden_v2.py
+++ b/tests/test_golden_v2.py
@@ -1,11 +1,36 @@
 #!/usr/bin/env python3
-import json, subprocess
+import json
+import subprocess
 from pathlib import Path
-R=Path(__file__).resolve().parents[1]; CLI=R/"cli"/"btcmi.py"
+
+R = Path(__file__).resolve().parents[1]
+CLI = R / "cli" / "btcmi.py"
+
+
 def _cmp(nm):
-    out=R/f"tests/tmp/{nm}.out.json"; gold=R/f"tests/golden/{nm}.golden.json"
-    r=subprocess.run(["python3",str(CLI),"run","--input",str(R/f"examples/{nm}.json"),"--out",str(out),"--fixed-ts","2025-01-01T00:00:00Z","--fractal"])
-    assert r.returncode==0
-    assert json.loads(out.read_text())==json.loads(gold.read_text())
-def test_intraday_fractal(): _cmp("intraday_fractal")
-def test_swing_fractal(): _cmp("swing_fractal")
+    out = R / f"tests/tmp/{nm}.out.json"
+    gold = R / f"tests/golden/{nm}.golden.json"
+    r = subprocess.run(
+        [
+            "python3",
+            str(CLI),
+            "run",
+            "--input",
+            str(R / f"examples/{nm}.json"),
+            "--out",
+            str(out),
+            "--fixed-ts",
+            "2025-01-01T00:00:00Z",
+            "--fractal",
+        ]
+    )
+    assert r.returncode == 0
+    assert json.loads(out.read_text()) == json.loads(gold.read_text())
+
+
+def test_intraday_fractal():
+    _cmp("intraday_fractal")
+
+
+def test_swing_fractal():
+    _cmp("swing_fractal")

--- a/tests/test_router_regime.py
+++ b/tests/test_router_regime.py
@@ -1,11 +1,25 @@
+#!/usr/bin/env python3
 import sys
 from pathlib import Path as _P
+
 sys.path.insert(0, str(_P(__file__).resolve().parents[1]))
-#!/usr/bin/env python3
+
 from btcmi.engine_v2 import router_weights
+
+
 def test_router_low():
-    regime,w=router_weights(0.1); assert regime=="low"; assert abs(sum(w.values())-1.0)<1e-9
+    regime, w = router_weights(0.1)
+    assert regime == "low"
+    assert abs(sum(w.values()) - 1.0) < 1e-9
+
+
 def test_router_mid():
-    regime,w=router_weights(0.5); assert regime=="mid"; assert abs(sum(w.values())-1.0)<1e-9
+    regime, w = router_weights(0.5)
+    assert regime == "mid"
+    assert abs(sum(w.values()) - 1.0) < 1e-9
+
+
 def test_router_high():
-    regime,w=router_weights(0.8); assert regime=="high"; assert abs(sum(w.values())-1.0)<1e-9
+    regime, w = router_weights(0.8)
+    assert regime == "high"
+    assert abs(sum(w.values()) - 1.0) < 1e-9


### PR DESCRIPTION
## Summary
- expand semicolon-chained assignments into separate lines across tests
- tidy router regime tests by splitting combined assertions
- format updated files with Ruff and Black

## Testing
- `ruff check tests/test_drift_guard.py tests/test_golden_v2.py tests/test_router_regime.py tests/test_golden_v1.py --fix`
- `black tests/test_drift_guard.py tests/test_golden_v2.py tests/test_router_regime.py tests/test_golden_v1.py`
- `pytest tests/test_drift_guard.py tests/test_golden_v2.py tests/test_router_regime.py tests/test_golden_v1.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2aee2ce208329aa0137817bcefe1d