### PR TITLE
refactor: centralize runner implementations

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sys
 
 from fastapi import FastAPI, HTTPException, Response
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from btcmi.runner import run_v1, run_v2
 from btcmi.schema_util import validate_json
-from cli.btcmi import run_v1, run_v2
 
 app = FastAPI()
 

--- a/cli/btcmi.py
+++ b/cli/btcmi.py
@@ -2,137 +2,16 @@
 from __future__ import annotations
 
 import argparse
-import datetime as dt
-import json
 import logging
 import sys
 from pathlib import Path
-from typing import Dict
 
 # Ensure local package importable
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from btcmi import engine_v1 as v1
-from btcmi import engine_v2 as v2
 from btcmi.logging_cfg import configure_logging, new_run_id
+from btcmi.runner import run_v1, run_v2
 from btcmi.schema_util import load_json, validate_json
-
-ALLOWED_SCENARIOS = frozenset(v1.SCENARIO_WEIGHTS.keys())
-
-
-def run_v1(data, fixed_ts, out_path):
-    scenario = data.get("scenario")
-    if scenario is None:
-        raise ValueError("'scenario' field is required")
-    if scenario not in ALLOWED_SCENARIOS:
-        raise ValueError(
-            "'scenario' must be one of: " + ", ".join(sorted(ALLOWED_SCENARIOS))
-        )
-
-    window = data.get("window")
-    if window is None:
-        raise ValueError("'window' field is required")
-
-    feats: Dict[str, float] = data.get("features", {})
-    norm = v1.normalize(feats)
-    base, weights, contrib = v1.base_signal(scenario, norm)
-    ng = v1.nagr_score(data.get("nagr_nodes", []))
-    overall = v1.combine(base, ng)
-    comp = v1.completeness(feats)
-    conf = round(0.5 + 0.5 * comp, 3)
-    notes: list[str] = []
-    constraints = False
-    if comp < 0.6:
-        notes.append("low_feature_completeness")
-    asof = fixed_ts or dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
-
-    out = {
-        "schema_version": data.get("schema_version", "2.0.0"),
-        "lineage": data.get("lineage", {}),
-        "asof": asof,
-        "summary": {
-            "scenario": scenario,
-            "window": window,
-            "overall_signal": round(overall, 6),
-            "confidence": conf,
-            "router_path": f"{scenario}/v1",
-            "nagr_score": round(ng, 6),
-            "advisories": notes,
-        },
-        "details": {
-            "normalized_features": {k: round(v, 6) for k, v in norm.items()},
-            "weights": v1.SCENARIO_WEIGHTS[scenario],
-            "contributions": {k: round(v, 6) for k, v in contrib.items()},
-            "constraints_applied": constraints,
-            "diagnostics": {"completeness": round(comp, 3), "notes": notes},
-        },
-    }
-    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
-    Path(out_path).write_text(json.dumps(out, indent=2), encoding="utf-8")
-    return out
-
-
-def run_v2(data, fixed_ts, out_path):
-    scenario = data.get("scenario")
-    if scenario is None:
-        raise ValueError("'scenario' field is required")
-    if scenario not in ALLOWED_SCENARIOS:
-        raise ValueError(
-            "'scenario' must be one of: " + ", ".join(sorted(ALLOWED_SCENARIOS))
-        )
-
-    window = data.get("window")
-    if window is None:
-        raise ValueError("'window' field is required")
-
-    f1 = data.get("features_micro", {})
-    f2 = data.get("features_mezo", {})
-    f3 = data.get("features_macro", {})
-    vol_pctl = float(data.get("vol_regime_pctl", 0.5))
-    n1 = v2.normalize_layer(f1, v2.SCALES["L1"])
-    n2 = v2.normalize_layer(f2, v2.SCALES["L2"])
-    n3 = v2.normalize_layer(f3, v2.SCALES["L3"])
-    w1 = v2.layer_equal_weights(n1)
-    w2 = v2.layer_equal_weights(n2)
-    w3 = v2.layer_equal_weights(n3)
-    s1, _ = v2.level_signal(n1, w1, data.get("nagr_nodes", []))
-    s2, _ = v2.level_signal(n2, w2, data.get("nagr_nodes", []))
-    s3, _ = v2.level_signal(n3, w3, data.get("nagr_nodes", []))
-    regime, alphas = v2.router_weights(vol_pctl)
-    overall = v2.combine_levels(s1, s2, s3, alphas)
-    coverage = sum(len(x) > 0 for x in [n1, n2, n3]) / 3.0
-    conf = round(0.5 + 0.5 * min(coverage, 1.0), 3)
-    notes: list[str] = []
-    asof = fixed_ts or dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
-
-    out = {
-        "schema_version": data.get("schema_version", "2.0.0"),
-        "lineage": data.get("lineage", {}),
-        "asof": asof,
-        "summary": {
-            "scenario": scenario,
-            "window": window,
-            "overall_signal": round(overall, 6),
-            "confidence": conf,
-            "router_path": f"{scenario}/v2.fractal",
-            "nagr_score": 0.0,
-            "advisories": notes,
-            "overall_signal_L1": round(s1, 6),
-            "overall_signal_L2": round(s2, 6),
-            "overall_signal_L3": round(s3, 6),
-            "level_weights": alphas,
-        },
-        "details": {
-            "normalized_micro": {k: round(v, 6) for k, v in n1.items()},
-            "normalized_mezo": {k: round(v, 6) for k, v in n2.items()},
-            "normalized_macro": {k: round(v, 6) for k, v in n3.items()},
-            "router_regime": regime,
-            "diagnostics": {"completeness": round(coverage, 3), "notes": notes},
-        },
-    }
-    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
-    Path(out_path).write_text(json.dumps(out, indent=2), encoding="utf-8")
-    return out
 
 
 def main() -> int:

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -1,13 +1,15 @@
 import json
+import sys
 from pathlib import Path
 
 from fastapi.testclient import TestClient
 from prometheus_client import CONTENT_TYPE_LATEST
 from prometheus_client.parser import text_string_to_metric_families
 
-from api.app import app, RUNNERS, REQUEST_COUNTER
-
 R = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(R))
+
+from api.app import app, RUNNERS, REQUEST_COUNTER
 
 
 def _load_example(name: str) -> dict:


### PR DESCRIPTION
## Summary
- import shared `run_v1` and `run_v2` from `btcmi.runner` instead of re-implementing them in the CLI
- update API to use `btcmi.runner` and ensure repo root is on `sys.path`
- align tests with the consolidated runner entry points

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2b3033b108329b0849a14d7aba075