### PR TITLE
fix: require jsonschema for schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ docker compose run --rm app --mode quick_brief --input /data/input.json --out /d
 
 ## Validation & integrity
 
+This project relies on the [`jsonschema`](https://pypi.org/project/jsonschema/)
+package for contract enforcement. Install it with `pip install jsonschema` if
+it's not already available.
+
 ```bash
 python tests/validate_output.py out.json
 sha256sum -c CHECKSUMS.SHA256

--- a/btcmi/schema_util.py
+++ b/btcmi/schema_util.py
@@ -1,24 +1,31 @@
 from pathlib import Path
 import json
-def load_json(p): 
+
+
+def load_json(p):
     return json.loads(Path(p).read_text(encoding="utf-8"))
+
+
 def validate_json(data, schema_path):
+    """Validate *data* against the JSON schema at *schema_path*.
+
+    Requires the external ``jsonschema`` package. Install it with
+    ``pip install jsonschema``.
+    """
+
     schema = load_json(schema_path)
     try:
         from jsonschema import Draft202012Validator
-    except ImportError:
-        if schema.get("type") == "object":
-            if not isinstance(data, dict):
-                raise ValueError("root: must be object")
-            for req in schema.get("required", []):
-                if req not in data:
-                    raise ValueError(f"{req}: is a required property")
-    else:
-        v = Draft202012Validator(schema)
-        errors = sorted(v.iter_errors(data), key=lambda e: e.path)
-        if errors:
-            msgs = []
-            for e in errors:
-                loc = "/".join(map(str, e.path))
-                msgs.append(f"{loc}: {e.message}")
-            raise ValueError("\n".join(msgs))
+    except ImportError as exc:  # pragma: no cover - exercised in tests
+        raise ImportError(
+            "jsonschema is required for validate_json. Install with `pip install jsonschema`."
+        ) from exc
+
+    v = Draft202012Validator(schema)
+    errors = sorted(v.iter_errors(data), key=lambda e: e.path)
+    if errors:
+        msgs = []
+        for e in errors:
+            loc = "/".join(map(str, e.path))
+            msgs.append(f"{loc}: {e.message}")
+        raise ValueError("\n".join(msgs))

--- a/tests/test_schema_util.py
+++ b/tests/test_schema_util.py
@@ -19,7 +19,7 @@ def test_validate_json_additional_properties(tmp_path):
 
 
 def test_validate_json_without_jsonschema(monkeypatch, tmp_path):
-    """Fallback performs minimal checks when jsonschema is absent."""
+    """Raises a clear ImportError when jsonschema is absent."""
     import sys
 
     # Simulate jsonschema being unavailable
@@ -33,15 +33,6 @@ def test_validate_json_without_jsonschema(monkeypatch, tmp_path):
     schema_path = tmp_path / "schema.json"
     schema_path.write_text(json.dumps(schema))
 
-    # Valid data should pass
-    validate_json({"foo": "bar"}, schema_path)
-
-    # Missing required field
-    with pytest.raises(ValueError) as err:
-        validate_json({}, schema_path)
-    assert "foo: is a required property" in str(err.value)
-
-    # Wrong root type
-    with pytest.raises(ValueError) as err:
-        validate_json([], schema_path)
-    assert "root: must be object" in str(err.value)
+    with pytest.raises(ImportError) as err:
+        validate_json({"foo": "bar"}, schema_path)
+    assert "jsonschema" in str(err.value)


### PR DESCRIPTION
## Summary
- raise a clear ImportError when `jsonschema` is missing
- document `jsonschema` requirement
- update tests for new behavior

## Testing
- `pytest tests/test_schema_util.py`
- `pre-commit run --files btcmi/schema_util.py tests/test_schema_util.py README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'api')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=68)*


------
https://chatgpt.com/codex/tasks/task_e_68b2b303b3348329b9f1b538c3534b50