### PR TITLE
Expand numeric type handling in is_number

### DIFF
--- a/btcmi/utils.py
+++ b/btcmi/utils.py
@@ -1,2 +1,9 @@
+"""Utility helpers for BTC Market Intelligence (BTCMI)."""
+
+from numbers import Number
+
+
 def is_number(x):
-    return isinstance(x, (int, float)) and not isinstance(x, bool)
+    """Return True if *x* is a numeric value (excluding bool)."""
+    return isinstance(x, Number) and not isinstance(x, bool)
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+from decimal import Decimal
+from fractions import Fraction
+
+import pytest
+
+
+# Allow tests to import the project modules directly.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from btcmi.utils import is_number
+
+
+@pytest.mark.parametrize(
+    "val",
+    [1, 1.0, 1 + 2j, Decimal("1.23"), Fraction(1, 3)],
+)
+def test_is_number_with_numeric_types(val):
+    """``is_number`` should return True for standard numeric objects."""
+    assert is_number(val)
+
+
+@pytest.mark.parametrize("val", [True, False, "1", None, [], object()])
+def test_is_number_with_non_numeric_types(val):
+    """``is_number`` should return False for non-numeric objects."""
+    assert not is_number(val)
+


### PR DESCRIPTION
## Summary
- use `numbers.Number` for robust numeric detection
- test `is_number` with Decimal, Fraction, complex, and bool exclusion

## Testing
- `pytest tests/test_utils.py -q`
- `PYTHONPATH=. pytest -q`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b2b3052f648329a43fa366c1fff350