### PR TITLE
docs: clarify API run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ btcmi run --mode execution_plan --input examples/input.sample.json --out out.jso
 python tests/validate_output.py out.json  # validate against output_schema.json
 ```
 
+### Run the API
+
+Run the API with:
+
+```bash
+uvicorn btcmi.api.app:app --reload
+```
+
 ### Platform notes
 
 Scientific libraries such as `numpy` and `scipy` may require native build


### PR DESCRIPTION
## Summary
- document uvicorn command for running the API

## Testing
- `go test ./...`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2bee485488329b6130cf71b99a83d