### PR TITLE
Make output path optional in runner

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -46,7 +46,7 @@ async def run_endpoint(payload: dict):
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     try:
-        result = runner(payload, None, "/dev/null")
+        result = runner(payload, None, out_path=None)
     except (KeyError, ValueError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:  # noqa: BLE001

--- a/btcmi/runner.py
+++ b/btcmi/runner.py
@@ -11,7 +11,7 @@ from btcmi import engine_v2 as v2
 ALLOWED_SCENARIOS = frozenset(v1.SCENARIO_WEIGHTS.keys())
 
 
-def run_v1(data, fixed_ts, out_path):
+def run_v1(data, fixed_ts, out_path: str | Path | None = None):
     scenario = data.get("scenario")
     if scenario is None:
         raise ValueError("'scenario' field is required")
@@ -53,12 +53,14 @@ def run_v1(data, fixed_ts, out_path):
             "diagnostics": {"completeness": round(comp, 3), "notes": notes},
         },
     }
-    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
-    Path(out_path).write_text(json.dumps(out, indent=2), encoding="utf-8")
+    if out_path is not None:
+        p = Path(out_path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(out, indent=2), encoding="utf-8")
     return out
 
 
-def run_v2(data, fixed_ts, out_path):
+def run_v2(data, fixed_ts, out_path: str | Path | None = None):
     scenario = data.get("scenario")
     if scenario is None:
         raise ValueError("'scenario' field is required")
@@ -111,8 +113,10 @@ def run_v2(data, fixed_ts, out_path):
             "diagnostics": {"completeness": round(coverage, 3), "notes": notes},
         },
     }
-    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
-    Path(out_path).write_text(json.dumps(out, indent=2), encoding="utf-8")
+    if out_path is not None:
+        p = Path(out_path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(out, indent=2), encoding="utf-8")
     return out
 
 

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -41,6 +41,21 @@ def test_run_runner_exception(monkeypatch):
     assert resp.status_code == 500
 
 
+def test_run_out_path_none(monkeypatch):
+    seen = {}
+
+    def runner(p, _t, *, out_path=None):
+        seen["out_path"] = out_path
+        return {"summary": {}}
+
+    monkeypatch.setitem(RUNNERS, "v1", runner)
+    client = TestClient(app)
+    payload = _load_example("intraday")
+    resp = client.post("/run", json=payload)
+    assert resp.status_code == 200
+    assert seen["out_path"] is None
+
+
 def test_validate_input_valid():
     client = TestClient(app)
     payload = _load_example("intraday")

--- a/tests/test_api_snapshots.py
+++ b/tests/test_api_snapshots.py
@@ -17,8 +17,14 @@ def _load_example(name: str) -> dict:
     return json.loads((R / "examples" / f"{name}.json").read_text())
 
 def _prepare_client(monkeypatch) -> TestClient:
-    monkeypatch.setitem(RUNNERS, "v1", lambda p, _t, o: run_v1(p, FIXED_TS, o))
-    monkeypatch.setitem(RUNNERS, "v2.fractal", lambda p, _t, o: run_v2(p, FIXED_TS, o))
+    def r1(p, _t, *, out_path=None):
+        return run_v1(p, FIXED_TS, out_path)
+
+    def r2(p, _t, *, out_path=None):
+        return run_v2(p, FIXED_TS, out_path)
+
+    monkeypatch.setitem(RUNNERS, "v1", r1)
+    monkeypatch.setitem(RUNNERS, "v2.fractal", r2)
     return TestClient(app)
 
 def _assert_snapshot(client: TestClient, payload: dict, golden: Path) -> None:

--- a/tests/test_golden_v1.py
+++ b/tests/test_golden_v1.py
@@ -1,27 +1,16 @@
 #!/usr/bin/env python3
 import json
-import subprocess
 from pathlib import Path
 
+from btcmi.runner import run_v1
+
 R = Path(__file__).resolve().parents[1]
-CLI = R / "cli" / "btcmi.py"
 
 
-def test_v1_intraday():
-    out = R / "tests/tmp/intraday_v1.out.json"
-    gold = R / "tests/golden/intraday_v1.golden.json"
-    r = subprocess.run(
-        [
-            "python3",
-            str(CLI),
-            "run",
-            "--input",
-            str(R / "examples/intraday.json"),
-            "--out",
-            str(out),
-            "--fixed-ts",
-            "2025-01-01T00:00:00Z",
-        ]
-    )
-    assert r.returncode == 0
-    assert json.loads(out.read_text()) == json.loads(gold.read_text())
+def test_v1_intraday(tmp_path):
+    data = json.loads((R / "examples/intraday.json").read_text())
+    out_path = tmp_path / "intraday_v1.out.json"
+    gold = json.loads((R / "tests/golden/intraday_v1.golden.json").read_text())
+    result = run_v1(data, "2025-01-01T00:00:00Z", out_path)
+    assert result == gold
+    assert json.loads(out_path.read_text()) == gold

--- a/tests/test_golden_v2.py
+++ b/tests/test_golden_v2.py
@@ -1,36 +1,24 @@
 #!/usr/bin/env python3
 import json
-import subprocess
 from pathlib import Path
 
+from btcmi.runner import run_v2
+
 R = Path(__file__).resolve().parents[1]
-CLI = R / "cli" / "btcmi.py"
 
 
-def _cmp(nm):
-    out = R / f"tests/tmp/{nm}.out.json"
-    gold = R / f"tests/golden/{nm}.golden.json"
-    r = subprocess.run(
-        [
-            "python3",
-            str(CLI),
-            "run",
-            "--input",
-            str(R / f"examples/{nm}.json"),
-            "--out",
-            str(out),
-            "--fixed-ts",
-            "2025-01-01T00:00:00Z",
-            "--fractal",
-        ]
-    )
-    assert r.returncode == 0
-    assert json.loads(out.read_text()) == json.loads(gold.read_text())
+def _cmp(nm: str, tmp_path: Path) -> None:
+    data = json.loads((R / f"examples/{nm}.json").read_text())
+    out_path = tmp_path / f"{nm}.out.json"
+    gold = json.loads((R / f"tests/golden/{nm}.golden.json").read_text())
+    result = run_v2(data, "2025-01-01T00:00:00Z", out_path)
+    assert result == gold
+    assert json.loads(out_path.read_text()) == gold
 
 
-def test_intraday_fractal():
-    _cmp("intraday_fractal")
+def test_intraday_fractal(tmp_path):
+    _cmp("intraday_fractal", tmp_path)
 
 
-def test_swing_fractal():
-    _cmp("swing_fractal")
+def test_swing_fractal(tmp_path):
+    _cmp("swing_fractal", tmp_path)


### PR DESCRIPTION
## Summary
- allow runner outputs to skip file creation unless an output path is supplied
- pass `out_path=None` through API to avoid unnecessary writes
- refactor golden tests to call runner functions directly and verify output

## Testing
- `pytest tests/test_api_app.py tests/test_golden_v1.py tests/test_golden_v2.py tests/test_api_snapshots.py`

------
https://chatgpt.com/codex/tasks/task_e_68b2cd2d51dc8329b2f896608ecc3105