### PR TITLE
refactor: centralize engine constants

### DIFF
--- a/btcmi/config.py
+++ b/btcmi/config.py
@@ -1,0 +1,57 @@
+"""Shared configuration constants for the BTC Market Intelligence engines."""
+
+SCENARIO_WEIGHTS = {
+    "intraday": {
+        "price_change_pct": 0.35,
+        "volume_change_pct": 0.25,
+        "funding_rate_bps": -0.10,
+        "oi_change_pct": 0.20,
+        "onchain_active_addrs_change_pct": 0.10,
+    },
+    "scalp": {
+        "price_change_pct": 0.45,
+        "volume_change_pct": 0.30,
+        "funding_rate_bps": -0.05,
+        "oi_change_pct": 0.15,
+        "onchain_active_addrs_change_pct": 0.05,
+    },
+    "swing": {
+        "price_change_pct": 0.25,
+        "volume_change_pct": 0.15,
+        "funding_rate_bps": -0.10,
+        "oi_change_pct": 0.25,
+        "onchain_active_addrs_change_pct": 0.25,
+    },
+}
+
+NORM_SCALE = {
+    "price_change_pct": 2.0,
+    "volume_change_pct": 50.0,
+    "funding_rate_bps": 10.0,
+    "oi_change_pct": 20.0,
+    "onchain_active_addrs_change_pct": 20.0,
+}
+
+SCALES = {
+    "L1": {
+        "price_change_pct": 2.0,
+        "volume_change_pct": 50.0,
+        "funding_rate_bps": 10.0,
+        "oi_change_pct": 20.0,
+        "micro_liquidity_gaps": 5.0,
+    },
+    "L2": {
+        "oi_term_structure_slope": 0.5,
+        "funding_premium_spread": 0.5,
+        "net_positioning_index": 0.5,
+        "liquidation_heatmap_entropy": 1.0,
+    },
+    "L3": {
+        "hashrate_trend": 0.5,
+        "active_addrs_trend": 0.5,
+        "supply_in_profit_pct": 0.5,
+        "macro_regime_score": 1.0,
+    },
+}
+
+__all__ = ["SCENARIO_WEIGHTS", "NORM_SCALE", "SCALES"]

--- a/btcmi/engine_v1.py
+++ b/btcmi/engine_v1.py
@@ -4,39 +4,10 @@ from __future__ import annotations
 from typing import Dict, Any
 import math
 from btcmi.utils import is_number
+from btcmi.config import NORM_SCALE, SCENARIO_WEIGHTS
 
 
 FeatureMap = Dict[str, float]
-SCENARIO_WEIGHTS = {
-    "intraday": {
-        "price_change_pct": 0.35,
-        "volume_change_pct": 0.25,
-        "funding_rate_bps": -0.10,
-        "oi_change_pct": 0.20,
-        "onchain_active_addrs_change_pct": 0.10,
-    },
-    "scalp": {
-        "price_change_pct": 0.45,
-        "volume_change_pct": 0.30,
-        "funding_rate_bps": -0.05,
-        "oi_change_pct": 0.15,
-        "onchain_active_addrs_change_pct": 0.05,
-    },
-    "swing": {
-        "price_change_pct": 0.25,
-        "volume_change_pct": 0.15,
-        "funding_rate_bps": -0.10,
-        "oi_change_pct": 0.25,
-        "onchain_active_addrs_change_pct": 0.25,
-    },
-}
-NORM_SCALE = {
-    "price_change_pct": 2.0,
-    "volume_change_pct": 50.0,
-    "funding_rate_bps": 10.0,
-    "oi_change_pct": 20.0,
-    "onchain_active_addrs_change_pct": 20.0,
-}
 
 
 def normalize(features: FeatureMap) -> FeatureMap:

--- a/btcmi/engine_v2.py
+++ b/btcmi/engine_v2.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Dict, List
 import math
 from btcmi.utils import is_number
+from btcmi.config import SCALES
 
 
 def tanh_norm(x: float, s: float) -> float:
@@ -129,27 +130,6 @@ def combine_levels(L1: float, L2: float, L3: float, w):
     return max(-1.0, min(1.0, s))
 
 
-SCALES = {
-    "L1": {
-        "price_change_pct": 2.0,
-        "volume_change_pct": 50.0,
-        "funding_rate_bps": 10.0,
-        "oi_change_pct": 20.0,
-        "micro_liquidity_gaps": 5.0,
-    },
-    "L2": {
-        "oi_term_structure_slope": 0.5,
-        "funding_premium_spread": 0.5,
-        "net_positioning_index": 0.5,
-        "liquidation_heatmap_entropy": 1.0,
-    },
-    "L3": {
-        "hashrate_trend": 0.5,
-        "active_addrs_trend": 0.5,
-        "supply_in_profit_pct": 0.5,
-        "macro_regime_score": 1.0,
-    },
-}
 
 
 def layer_equal_weights(norm: Dict[str, float]) -> Dict[str, float]:


### PR DESCRIPTION
## Summary
- centralize scenario weights, normalization scales and layer scales in `btcmi.config`
- import shared constants from `config` in `engine_v1` and `engine_v2`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2ce9d09d88329845004e740b8a085