### PR TITLE
Handle schema validation errors

### DIFF
--- a/cli/btcmi.py
+++ b/cli/btcmi.py
@@ -81,7 +81,11 @@ def main() -> int:
         return 0
 
     data = load_json(args.data)
-    validate_json(data, args.schema)
+    try:
+        validate_json(data, args.schema)
+    except Exception:
+        logger.exception("schema_validation_failed", extra={"run_id": run_id})
+        return 2
     print("OK")
     return 0
 

--- a/tests/test_cli_required_fields.py
+++ b/tests/test_cli_required_fields.py
@@ -1,6 +1,14 @@
 import pytest
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from btcmi.runner import run_v1, run_v2
+
+R = Path(__file__).resolve().parents[1]
+CLI = R / "cli" / "btcmi.py"
 
 def test_run_v1_missing_scenario(tmp_path):
     data = {"window": "intraday"}
@@ -36,3 +44,21 @@ def test_run_v2_invalid_scenario(tmp_path):
     data = {"scenario": "invalid", "window": "intraday"}
     with pytest.raises(ValueError, match="scenario"):
         run_v2(data, None, tmp_path / "out.json")
+
+
+def test_validate_cli_returns_code_2(tmp_path):
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{}")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "validate",
+            "--schema",
+            str(R / "input_schema.json"),
+            "--data",
+            str(invalid),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 2


### PR DESCRIPTION
## Summary
- return exit code 2 when `btcmi validate` fails schema validation
- log validation failures via `logger.exception`
- test CLI validation error exit code

## Testing
- `pytest tests/test_cli_required_fields.py`
- `pre-commit run --files cli/btcmi.py tests/test_cli_required_fields.py` *(fail: command not found)*
- `pip install pre-commit` *(fail: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cfbeb3148329b4c3a912ac601527