### PR TITLE
docs: add HTTP API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Production-grade toolkit for Bitcoin market intelligence: strict data contracts,
 * **Data contracts:** `input_schema.json`, `output_schema.json`
 * **Validation & integrity:** structural validator, checksums, SBOM/provenance
 * **Observability:** Prometheus job, Grafana dashboard
+* **HTTP API:** `/run`, `/validate/{schema}`, `/metrics`, `/healthz` ([docs/API.md](docs/API.md))
 * **Containerized runtime:** Docker Compose
 * **Versioning:** semantic tags, `VERSION`, `CHANGELOG.md`
 * **Conventional Commits** for history hygiene

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,101 @@
+# HTTP API
+
+This service exposes a minimal FastAPI interface for running analyses, validating JSON payloads and reporting status.
+
+## `POST /run`
+
+Execute an analysis run. The payload must conform to `input_schema.json` and specify the desired mode (`v1` or `v2.fractal`).
+
+### Example
+
+```bash
+curl -X POST http://localhost:8000/run \
+  -H 'Content-Type: application/json' \
+  -d @examples/intraday.json
+```
+
+**Response**
+
+```json
+{
+  "meta": {"mode": "v1", "ts": "2025-01-01T00:00:00Z"},
+  "dashboard": {"summary": "..."}
+}
+```
+
+**Error codes**
+
+| code | reason                          |
+|------|---------------------------------|
+| 400  | unknown mode or validation fail |
+| 500  | internal error                  |
+
+## `POST /validate/{schema}`
+
+Validate a payload against a registered schema (`input` or `output`).
+
+### Example
+
+```bash
+curl -X POST http://localhost:8000/validate/input \
+  -H 'Content-Type: application/json' \
+  -d @examples/intraday.json
+```
+
+**Response**
+
+```json
+{"valid": true}
+```
+
+**Error codes**
+
+| code | reason                |
+|------|-----------------------|
+| 400  | validation failed     |
+| 404  | schema not found      |
+
+## `GET /metrics`
+
+Prometheus metrics endpoint.
+
+### Example
+
+```bash
+curl http://localhost:8000/metrics
+```
+
+**Response**
+
+```
+btcmi_requests_total{endpoint="/run"} 1
+```
+
+**Error codes**
+
+| code | reason             |
+|------|--------------------|
+| 500  | internal error     |
+
+## `GET /healthz`
+
+Simple health check.
+
+### Example
+
+```bash
+curl http://localhost:8000/healthz
+```
+
+**Response**
+
+```json
+{"status": "ok"}
+```
+
+**Error codes**
+
+| code | reason         |
+|------|----------------|
+| 500  | internal error |
+


### PR DESCRIPTION
## Summary
- document HTTP API endpoints with examples and error codes
- link API documentation from README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2d0f534c08329a3a46b153e5703d5