### PR TITLE
Ensure CLI run exits with code 2 on invalid input

### DIFF
--- a/cli/btcmi.py
+++ b/cli/btcmi.py
@@ -41,7 +41,10 @@ def main() -> int:
                 data, Path(__file__).resolve().parents[1] / "input_schema.json"
             )
         except Exception:
-            logger.warning("input_schema_validation_failed", extra={"run_id": run_id})
+            logger.error(
+                "input_schema_validation_failed", extra={"run_id": run_id}
+            )
+            return 2
 
         # If explicit mode present, enforce consistency with --fractal flag
         mode = data.get("mode")

--- a/tests/test_cli_required_fields.py
+++ b/tests/test_cli_required_fields.py
@@ -63,3 +63,23 @@ def test_validate_cli_returns_code_2(tmp_path):
         capture_output=True,
     )
     assert result.returncode == 2
+
+
+def test_run_cli_returns_code_2_on_invalid_input(tmp_path):
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{}")
+    out = tmp_path / "out.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            CLI,
+            "run",
+            "--input",
+            str(invalid),
+            "--out",
+            str(out),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 2


### PR DESCRIPTION
## Summary
- fail fast when `btcmi run` input schema validation fails and log error
- test run command exit code for invalid input

## Testing
- `pytest tests/test_cli_required_fields.py -q`
- `pre-commit run --files cli/btcmi.py tests/test_cli_required_fields.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d88345a0832986846d478fd9ce8b