### PR TITLE
Configure pytest path for tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_cli_required_fields.py
+++ b/tests/test_cli_required_fields.py
@@ -3,8 +3,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
 from btcmi.runner import run_v1, run_v2
 
 R = Path(__file__).resolve().parents[1]

--- a/tests/test_engine_v2_layers.py
+++ b/tests/test_engine_v2_layers.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-import sys
-from pathlib import Path
 import pytest
-
-# Allow tests to import the project modules directly.
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from btcmi.engine_v2 import (
     normalize_layer,

--- a/tests/test_logging_cfg.py
+++ b/tests/test_logging_cfg.py
@@ -1,9 +1,6 @@
 import json
 import logging
-import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from btcmi.logging_cfg import configure_logging, new_run_id
 
 

--- a/tests/test_router_regime.py
+++ b/tests/test_router_regime.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python3
-import sys
-from pathlib import Path as _P
-
-sys.path.insert(0, str(_P(__file__).resolve().parents[1]))
 
 from btcmi.engine_v2 import router_weights
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,8 @@
-import sys
-from pathlib import Path
 from decimal import Decimal
 from fractions import Fraction
 
 import pytest
 
-
-# Allow tests to import the project modules directly.
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from btcmi.utils import is_number
 
 


### PR DESCRIPTION
## Summary
- remove manual `sys.path` tweaks from tests
- set up `pytest.ini` to add project root to `PYTHONPATH`

## Testing
- `pytest -q`
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dcca58c48329b2a2df2e1d032c67