### PR TITLE
Add schema caching for schema_util

### DIFF
--- a/btcmi/schema_util.py
+++ b/btcmi/schema_util.py
@@ -2,8 +2,20 @@ from pathlib import Path
 import json
 
 
+_SCHEMA_CACHE: dict[str, dict] = {}
+
+
 def load_json(p):
     return json.loads(Path(p).read_text(encoding="utf-8"))
+
+
+def _load_schema(schema_path):
+    key = str(schema_path)
+    schema = _SCHEMA_CACHE.get(key)
+    if schema is None:
+        schema = load_json(schema_path)
+        _SCHEMA_CACHE[key] = schema
+    return schema
 
 
 def validate_json(data, schema_path):
@@ -13,7 +25,7 @@ def validate_json(data, schema_path):
     ``pip install jsonschema``.
     """
 
-    schema = load_json(schema_path)
+    schema = _load_schema(schema_path)
     try:
         from jsonschema import Draft202012Validator
     except ImportError as exc:  # pragma: no cover - exercised in tests

--- a/tests/test_schema_util.py
+++ b/tests/test_schema_util.py
@@ -1,6 +1,11 @@
 import json
+from pathlib import Path
+
 import pytest
+
+from btcmi import schema_util
 from btcmi.schema_util import validate_json
+
 
 def test_validate_json_additional_properties(tmp_path):
     pytest.importorskip("jsonschema")
@@ -36,3 +41,27 @@ def test_validate_json_without_jsonschema(monkeypatch, tmp_path):
     with pytest.raises(ImportError) as err:
         validate_json({"foo": "bar"}, schema_path)
     assert "jsonschema" in str(err.value)
+
+
+def test_schema_cached(monkeypatch, tmp_path):
+    pytest.importorskip("jsonschema")
+    schema_util._SCHEMA_CACHE.clear()
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+    }
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text(json.dumps(schema))
+
+    calls = 0
+    original = Path.read_text
+
+    def fake_read_text(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+    validate_json({}, schema_path)
+    validate_json({}, schema_path)
+    assert calls == 1


### PR DESCRIPTION
## Summary
- cache JSON schemas in `schema_util` to avoid repeated disk reads
- add unit test verifying schema caching mechanism

## Testing
- `python -m black btcmi/schema_util.py tests/test_schema_util.py`
- `ruff check btcmi/schema_util.py tests/test_schema_util.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2de00500c8329a5455a63a682b9bc