### PR TITLE
refactor: make output path optional

### DIFF
--- a/btcmi/api.py
+++ b/btcmi/api.py
@@ -66,6 +66,8 @@ async def run_endpoint(payload: RunRequest) -> RunResponse:
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     try:
+        # API requests should not leave artifacts on disk; explicitly disable
+        # writing the output file.
         result = runner(data, None, out_path=None)
     except (KeyError, ValueError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/btcmi/runner.py
+++ b/btcmi/runner.py
@@ -13,6 +13,20 @@ ALLOWED_SCENARIOS = frozenset(SCENARIO_WEIGHTS.keys())
 
 
 def run_v1(data, fixed_ts, out_path: str | Path | None = None):
+    """Run the v1 engine and optionally persist the output.
+
+    Parameters
+    ----------
+    data:
+        Input payload conforming to the input schema.
+    fixed_ts:
+        Timestamp used for the ``asof`` field.  When ``None`` the current
+        UTC time is used.
+    out_path:
+        Optional path where the rendered JSON output should be written.  When
+        ``None`` (the default) the output is only returned and no file is
+        created.
+    """
     scenario = data.get("scenario")
     if scenario is None:
         raise ValueError("'scenario' field is required")
@@ -62,6 +76,7 @@ def run_v1(data, fixed_ts, out_path: str | Path | None = None):
 
 
 def run_v2(data, fixed_ts, out_path: str | Path | None = None):
+    """Run the v2 fractal engine and optionally persist the output."""
     scenario = data.get("scenario")
     if scenario is None:
         raise ValueError("'scenario' field is required")

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -42,7 +42,7 @@ def test_run_runner_exception(monkeypatch):
 def test_run_out_path_none(monkeypatch):
     seen = {}
 
-    def runner(p, _t, *, out_path=None):
+    def runner(p, _t, *, out_path: str | Path | None = None):
         seen["out_path"] = out_path
         return {
             "schema_version": "2.0.0",

--- a/tests/test_golden_v1.py
+++ b/tests/test_golden_v1.py
@@ -11,6 +11,6 @@ def test_v1_intraday(tmp_path):
     data = json.loads((R / "examples/intraday.json").read_text())
     out_path = tmp_path / "intraday_v1.out.json"
     gold = json.loads((R / "tests/golden/intraday_v1.golden.json").read_text())
-    result = run_v1(data, "2025-01-01T00:00:00Z", out_path)
+    result = run_v1(data, "2025-01-01T00:00:00Z", out_path=out_path)
     assert result == gold
     assert json.loads(out_path.read_text()) == gold

--- a/tests/test_golden_v2.py
+++ b/tests/test_golden_v2.py
@@ -11,7 +11,7 @@ def _cmp(nm: str, tmp_path: Path) -> None:
     data = json.loads((R / f"examples/{nm}.json").read_text())
     out_path = tmp_path / f"{nm}.out.json"
     gold = json.loads((R / f"tests/golden/{nm}.golden.json").read_text())
-    result = run_v2(data, "2025-01-01T00:00:00Z", out_path)
+    result = run_v2(data, "2025-01-01T00:00:00Z", out_path=out_path)
     assert result == gold
     assert json.loads(out_path.read_text()) == gold
 


### PR DESCRIPTION
## Summary
- document optional output path in runner and skip writing when absent
- ensure API requests pass `out_path=None`
- update tests for optional output file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2e403a4d88329a6114e7f0cd28b5c