### PR TITLE
Log validation errors for invalid CLI input

### DIFF
--- a/cli/btcmi.py
+++ b/cli/btcmi.py
@@ -41,7 +41,7 @@ def main() -> int:
                 data, Path(__file__).resolve().parents[1] / "input_schema.json"
             )
         except Exception:
-            logger.error(
+            logger.exception(
                 "input_schema_validation_failed", extra={"run_id": run_id}
             )
             return 2
@@ -63,7 +63,7 @@ def main() -> int:
                 out, Path(__file__).resolve().parents[1] / "output_schema.json"
             )
         except Exception:
-            logger.error(
+            logger.exception(
                 "output_schema_validation_failed",
                 extra={"run_id": run_id, "mode": mode},
             )

--- a/tests/test_cli_required_fields.py
+++ b/tests/test_cli_required_fields.py
@@ -81,3 +81,24 @@ def test_run_cli_returns_code_2_on_invalid_input(tmp_path):
         capture_output=True,
     )
     assert result.returncode == 2
+
+
+def test_run_cli_logs_validation_error(tmp_path):
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{}")
+    out = tmp_path / "out.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            CLI,
+            "run",
+            "--input",
+            str(invalid),
+            "--out",
+            str(out),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 2
+    assert b"input_schema_validation_failed" in result.stderr


### PR DESCRIPTION
## Summary
- log schema validation failures with stack traces in CLI and exit with status 2
- add regression test ensuring invalid CLI input reports validation error

## Testing
- `pytest tests/test_cli_required_fields.py`
- ⚠️ `pre-commit run --files cli/btcmi.py tests/test_cli_required_fields.py` *(missing pre-commit dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e7a2f6088329963b17dff47d01d2