### PR TITLE
docs: document HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Start the HTTP API server:
 uvicorn btcmi.api:app
 ```
 
+Refer to [docs/API.md](docs/API.md) for available endpoints and examples.
+
 ### Platform notes
 
 Scientific libraries such as `numpy` and `scipy` may require native build

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,13 @@
 
 This service exposes a minimal FastAPI interface for running analyses, validating JSON payloads and reporting status.
 
+Available endpoints:
+
+- `POST /run` – execute an analysis run.
+- `POST /validate/{schema}` – validate payloads against `input` or `output` schemas.
+- `GET /metrics` – expose Prometheus metrics.
+- `GET /healthz` – health check for liveness monitoring.
+
 ## Running the server
 
 After installing `btcmi`, launch the API with:


### PR DESCRIPTION
## Summary
- document available API endpoints in `docs/API.md`
- link `docs/API.md` from README's API server section

## Testing
- `pytest -q`
- `pre-commit run --files docs/API.md README.md` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e87abbb483299cc51d89828a2f03