### PR TITLE
Validate CLI mode option

### DIFF
--- a/cli/btcmi.py
+++ b/cli/btcmi.py
@@ -49,6 +49,11 @@ def main() -> int:
 
         # If explicit mode present, enforce consistency with --fractal flag
         mode = data.get("mode")
+        if mode not in (None, "v1", "v2.fractal"):
+            logger.error(
+                "unknown_mode", extra={"run_id": run_id, "mode": mode}
+            )
+            return 2
         if mode == "v1" and args.fractal:
             logger.warning("mode_flag_mismatch", extra={"run_id": run_id, "mode": mode})
         if mode == "v2.fractal" and not args.fractal:


### PR DESCRIPTION
## Summary
- validate `mode` in CLI to allow only `v1` or `v2.fractal`
- log `unknown_mode` and exit with code 2 for invalid modes
- add regression test for unknown mode value

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2ef6ecf348329b6367ace9723e906