### PR TITLE
refactor: centralize scenario window validation

### DIFF
--- a/btcmi/runner.py
+++ b/btcmi/runner.py
@@ -12,6 +12,22 @@ from btcmi.config import SCENARIO_WEIGHTS
 ALLOWED_SCENARIOS = frozenset(SCENARIO_WEIGHTS.keys())
 
 
+def _validate_scenario_window(data: dict) -> tuple[str, str]:
+    """Return the scenario and window ensuring both are valid."""
+
+    scenario = data.get("scenario")
+    if scenario is None:
+        raise ValueError("'scenario' field is required")
+    if scenario not in ALLOWED_SCENARIOS:
+        raise ValueError(
+            "'scenario' must be one of: " + ", ".join(sorted(ALLOWED_SCENARIOS))
+        )
+    window = data.get("window")
+    if window is None:
+        raise ValueError("'window' field is required")
+    return scenario, window
+
+
 def run_v1(data, fixed_ts, out_path: str | Path | None = None):
     """Run the v1 engine and optionally persist the output.
 
@@ -27,14 +43,7 @@ def run_v1(data, fixed_ts, out_path: str | Path | None = None):
         ``None`` (the default) the output is only returned and no file is
         created.
     """
-    scenario = data.get("scenario")
-    if scenario is None:
-        raise ValueError("'scenario' field is required")
-    if scenario not in ALLOWED_SCENARIOS:
-        raise ValueError("'scenario' must be one of: " + ", ".join(sorted(ALLOWED_SCENARIOS)))
-    window = data.get("window")
-    if window is None:
-        raise ValueError("'window' field is required")
+    scenario, window = _validate_scenario_window(data)
     feats: Dict[str, float] = data.get("features", {})
     norm = v1.normalize(feats)
     base, weights, contrib = v1.base_signal(scenario, norm)
@@ -77,14 +86,7 @@ def run_v1(data, fixed_ts, out_path: str | Path | None = None):
 
 def run_v2(data, fixed_ts, out_path: str | Path | None = None):
     """Run the v2 fractal engine and optionally persist the output."""
-    scenario = data.get("scenario")
-    if scenario is None:
-        raise ValueError("'scenario' field is required")
-    if scenario not in ALLOWED_SCENARIOS:
-        raise ValueError("'scenario' must be one of: " + ", ".join(sorted(ALLOWED_SCENARIOS)))
-    window = data.get("window")
-    if window is None:
-        raise ValueError("'window' field is required")
+    scenario, window = _validate_scenario_window(data)
     f1 = data.get("features_micro", {})
     f2 = data.get("features_mezo", {})
     f3 = data.get("features_macro", {})

--- a/tests/test_validate_scenario_window.py
+++ b/tests/test_validate_scenario_window.py
@@ -1,0 +1,25 @@
+import pytest
+
+from btcmi.runner import _validate_scenario_window
+
+
+def test_validate_returns_values():
+    data = {"scenario": "intraday", "window": "1h"}
+    scenario, window = _validate_scenario_window(data)
+    assert scenario == "intraday"
+    assert window == "1h"
+
+
+def test_validate_missing_scenario():
+    with pytest.raises(ValueError, match="scenario"):
+        _validate_scenario_window({"window": "1h"})
+
+
+def test_validate_invalid_scenario():
+    with pytest.raises(ValueError, match="scenario"):
+        _validate_scenario_window({"scenario": "invalid", "window": "1h"})
+
+
+def test_validate_missing_window():
+    with pytest.raises(ValueError, match="window"):
+        _validate_scenario_window({"scenario": "intraday"})


### PR DESCRIPTION
## Summary
- add `_validate_scenario_window` to ensure scenario and window fields exist and scenario allowed
- reuse validation helper in `run_v1` and `run_v2`
- add tests covering the new helper to preserve behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2f1465b308329a51994de9cb19843