### PR TITLE
Add explicit mode argument to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Run:
 
 ```bash
 # Option 1: use module path directly
-python -m cli.btcmi run --input examples/intraday.json --out out.json
+python -m cli.btcmi run --input examples/intraday.json --out out.json --mode v1
 # Option 2: after installation, invoke the script
-btcmi run --input examples/intraday.json --out out.json
+btcmi run --input examples/intraday.json --out out.json --mode v1
 # Enable Fractal Engine v2
-btcmi run --input examples/intraday_fractal.json --out out_fractal.json --fractal
+btcmi run --input examples/intraday_fractal.json --out out_fractal.json --mode v2.fractal
 python tests/validate_output.py out.json  # validate against output_schema.json
 ```
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,8 +1,8 @@
 # Quickstart
 ## v1 (baseline)
-btcmi run --input examples/intraday.json --out outputs/intraday_v1.out.json --fixed-ts 2025-01-01T00:00:00Z
+btcmi run --input examples/intraday.json --out outputs/intraday_v1.out.json --mode v1 --fixed-ts 2025-01-01T00:00:00Z
 ## v2 Fractal
-btcmi run --input examples/intraday_fractal.json --out outputs/intraday_v2.out.json --fractal --fixed-ts 2025-01-01T00:00:00Z
+btcmi run --input examples/intraday_fractal.json --out outputs/intraday_v2.out.json --mode v2.fractal --fixed-ts 2025-01-01T00:00:00Z
 ## End-to-end evaluation
 python examples/run_e2e.py
 

--- a/examples/run_e2e.py
+++ b/examples/run_e2e.py
@@ -41,9 +41,9 @@ def run_example(path: Path) -> Tuple[float, float]:
             str(input_path),
             "--out",
             str(output_path),
+            "--mode",
+            inp.get("mode", "v1"),
         ]
-        if inp.get("mode") == "v2.fractal":
-            cmd.append("--fractal")
         subprocess.run(cmd, check=True)
         out = json.loads(output_path.read_text(encoding="utf-8"))
     pred = float(out["summary"]["overall_signal"])

--- a/tests/test_cli_required_fields.py
+++ b/tests/test_cli_required_fields.py
@@ -79,6 +79,8 @@ def test_run_cli_returns_code_2_on_invalid_input(tmp_path):
             str(invalid),
             "--out",
             str(out),
+            "--mode",
+            "v1",
         ],
         capture_output=True,
     )
@@ -99,6 +101,8 @@ def test_run_cli_logs_validation_error(tmp_path):
             str(invalid),
             "--out",
             str(out),
+            "--mode",
+            "v1",
         ],
         capture_output=True,
     )
@@ -122,6 +126,8 @@ def test_run_cli_returns_code_2_on_missing_scenario(monkeypatch, tmp_path):
             str(invalid),
             "--out",
             str(out),
+            "--mode",
+            "v1",
         ],
         capture_output=True,
     )
@@ -144,6 +150,8 @@ def test_run_cli_returns_code_2_on_missing_window(monkeypatch, tmp_path):
             str(invalid),
             "--out",
             str(out),
+            "--mode",
+            "v1",
         ],
         capture_output=True,
     )
@@ -169,6 +177,8 @@ def test_run_cli_returns_code_2_on_unknown_mode(monkeypatch, tmp_path, capsys):
         str(invalid),
         "--out",
         str(out),
+        "--mode",
+        "v1",
     ]
     monkeypatch.setattr(sys, "argv", argv)
     code = btcmi.main()
@@ -186,6 +196,8 @@ def test_run_cli_prints_json_without_out():
             "run",
             "--input",
             str(R / "examples/intraday.json"),
+            "--mode",
+            "v1",
         ],
         capture_output=True,
         text=True,

--- a/tests/test_drift_guard.py
+++ b/tests/test_drift_guard.py
@@ -22,6 +22,8 @@ def test_drift_guard_mid():
             str(out1),
             "--fixed-ts",
             "2025-01-01T00:00:00Z",
+            "--mode",
+            "v1",
         ]
     )
     assert r1.returncode == 0
@@ -57,7 +59,8 @@ def test_drift_guard_mid():
             str(out2),
             "--fixed-ts",
             "2025-01-01T00:00:00Z",
-            "--fractal",
+            "--mode",
+            "v2.fractal",
         ]
     )
     assert r2.returncode == 0


### PR DESCRIPTION
## Summary
- replace `--fractal` flag with required `--mode` argument
- use CLI mode as source of truth and warn on mismatched JSON mode
- update documentation, example script, and tests for the new flag

## Testing
- `pytest tests/test_cli_required_fields.py tests/test_drift_guard.py`

------
https://chatgpt.com/codex/tasks/task_e_68b2f14894d8832980f28a2d753c1c9e