### PR TITLE
build: source version from VERSION file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Production-grade toolkit for Bitcoin market intelligence: strict data contracts,
 * **Observability:** Prometheus job, Grafana dashboard
 * **HTTP API:** `/run`, `/validate/{schema}`, `/metrics`, `/healthz` ([docs/API.md](docs/API.md))
 * **Containerized runtime:** Docker Compose
-* **Versioning:** semantic tags, `VERSION`, `CHANGELOG.md`
+* **Versioning:** update the root `VERSION` file (single source of truth) and sync `CHANGELOG.md`
 * **Conventional Commits** for history hygiene
 
 ## Repository layout
@@ -113,9 +113,10 @@ python scripts/verify_checksums.py
 
 ## Releases
 
-1. Tag `vX.Y.Z`
-2. Create GitHub Release with `CHANGELOG.md` excerpt
-3. Attach distributable ZIP as artifact
+1. Update `VERSION` and `CHANGELOG.md`
+2. Tag `vX.Y.Z`
+3. Create GitHub Release with `CHANGELOG.md` excerpt
+4. Attach distributable ZIP as artifact
 
 ## Contributing
 

--- a/btcmi/__init__.py
+++ b/btcmi/__init__.py
@@ -1,2 +1,4 @@
-__version__="1.2.1"
-__all__=["engine_v1","engine_v2","logging_cfg","schema_util","utils"]
+from pathlib import Path
+
+__version__ = (Path(__file__).resolve().parent.parent / "VERSION").read_text().strip()
+__all__ = ["engine_v1", "engine_v2", "logging_cfg", "schema_util", "utils"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 [project]
 name = "btcmi"
-version = "1.2.1"
 description = "BTC Market Intelligence with Fractal Engine v2."
 readme = "docs/QUICKSTART.md"
 requires-python = ">=3.10"
@@ -22,6 +21,7 @@ dependencies = [
 ]
 authors = [{name="BTCMI Team"}]
 license = {text="MIT"}
+dynamic = ["version"]
 [project.optional-dependencies]
 dev = [
     "black>=24.4.2",
@@ -30,6 +30,12 @@ dev = [
 ]
 [project.scripts]
 btcmi = "cli.btcmi:main"
+
+[tool.setuptools.dynamic]
+version = {file = "VERSION"}
+
+[tool.setuptools.data-files]
+"" = ["VERSION"]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Summary
- configure setuptools to read project version from the VERSION file
- expose package version from the same VERSION file at runtime
- document VERSION file as the single source for release version bumps

## Testing
- ⚠️ `pre-commit run --files pyproject.toml btcmi/__init__.py README.md` *(pre-commit installation failed: 403 Forbidden)*
- ✅ `black btcmi/__init__.py`
- ✅ `ruff check btcmi/__init__.py pyproject.toml README.md`
- ✅ `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2f374694883299b93a2aed8f85d0e