### PR TITLE
Add py.typed marker for btcmi package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include btcmi/py.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ version = {file = "VERSION"}
 [tool.setuptools.data-files]
 "" = ["VERSION"]
 
+[tool.setuptools.package-data]
+btcmi = ["py.typed"]
+
 [tool.black]
 line-length = 88
 target-version = ["py311"]


### PR DESCRIPTION
## Summary
- add empty `py.typed` marker file to expose typing information
- include `py.typed` in setuptools package data and MANIFEST

## Testing
- `pre-commit run --files pyproject.toml MANIFEST.in btcmi/py.typed` *(fails: command not found and package install blocked)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2f4ea327c8329903b96a1aba673cc