### PR TITLE
Add package docstring and format init

### DIFF
--- a/btcmi/__init__.py
+++ b/btcmi/__init__.py
@@ -1,4 +1,14 @@
+"""BTC Market Intelligence package initialization."""
+
 from pathlib import Path
 
-__version__ = (Path(__file__).resolve().parent.parent / "VERSION").read_text().strip()
-__all__ = ["engine_v1", "engine_v2", "logging_cfg", "schema_util", "utils"]
+VERSION_FILE = Path(__file__).resolve().parent.parent / "VERSION"
+__version__ = VERSION_FILE.read_text().strip()
+
+__all__ = [
+    "engine_v1",
+    "engine_v2",
+    "logging_cfg",
+    "schema_util",
+    "utils",
+]


### PR DESCRIPTION
## Summary
- Add a short package docstring to `btcmi` and cleanly structure initialization
- Format `__version__` and `__all__` definitions across multiple lines for readability

## Testing
- `ruff check --fix btcmi/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f5a657fc8329bb9275a50b0347aa