### PR TITLE
Use enums for scenario and window

### DIFF
--- a/btcmi/api.py
+++ b/btcmi/api.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from typing import Any, Dict
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest
 
+from btcmi.enums import Scenario, Window
 from btcmi.runner import run_v1, run_v2
 from btcmi.schema_util import validate_json
 
@@ -35,7 +36,17 @@ async def count_requests(request, call_next):
 
 
 class RunRequest(BaseModel):
+    scenario: Scenario
+    window: Window
     mode: str = "v1"
+
+    class Config:
+        extra = "allow"
+
+
+class Summary(BaseModel):
+    scenario: Scenario
+    window: Window
 
     class Config:
         extra = "allow"
@@ -44,7 +55,7 @@ class RunRequest(BaseModel):
 class RunResponse(BaseModel):
     schema_version: str
     lineage: Dict[str, str]
-    summary: Dict[str, Any]
+    summary: Summary
     details: Dict[str, Any]
     asof: str
 

--- a/btcmi/enums.py
+++ b/btcmi/enums.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Scenario(str, Enum):
+    INTRADAY = "intraday"
+    SCALP = "scalp"
+    SWING = "swing"
+
+
+class Window(str, Enum):
+    ONE_HOUR = "1h"
+    ONE_DAY = "1d"
+
+
+__all__ = ["Scenario", "Window"]

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -25,7 +25,7 @@ def test_run_success():
 def test_run_invalid_payload():
     client = TestClient(app)
     resp = client.post("/run", json={"mode": "v1"})
-    assert resp.status_code == 400
+    assert resp.status_code == 422
 
 
 def test_run_runner_exception(monkeypatch):
@@ -47,7 +47,7 @@ def test_run_out_path_none(monkeypatch):
         return {
             "schema_version": "2.0.0",
             "lineage": {},
-            "summary": {},
+            "summary": {"scenario": "intraday", "window": "1h"},
             "details": {},
             "asof": "1970-01-01T00:00:00Z",
         }

--- a/tests/test_validate_scenario_window.py
+++ b/tests/test_validate_scenario_window.py
@@ -1,13 +1,14 @@
 import pytest
 
+from btcmi.enums import Scenario, Window
 from btcmi.runner import _validate_scenario_window
 
 
 def test_validate_returns_values():
     data = {"scenario": "intraday", "window": "1h"}
     scenario, window = _validate_scenario_window(data)
-    assert scenario == "intraday"
-    assert window == "1h"
+    assert scenario is Scenario.INTRADAY
+    assert window is Window.ONE_HOUR
 
 
 def test_validate_missing_scenario():


### PR DESCRIPTION
## Summary
- add Scenario and Window enums
- use enums in runner validation and outputs
- type API request/response models to use new enums
- adjust tests for enum-based validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f79144508329ac994d2df68bfdb1