### PR TITLE
feat(cli): support stdin input

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Run:
 python -m cli.btcmi run --input examples/intraday.json --out out.json --mode v1
 # Option 2: after installation, invoke the script
 btcmi run --input examples/intraday.json --out out.json --mode v1
+# Option 3: pipe data via stdin
+cat examples/intraday.json | btcmi run --input - --mode v1
+curl -s https://example.com/intraday.json | btcmi run --input - --mode v1
 # Enable Fractal Engine v2
 btcmi run --input examples/intraday_fractal.json --out out_fractal.json --mode v2.fractal
 python tests/validate_output.py out.json  # validate against output_schema.json

--- a/cli/btcmi.py
+++ b/cli/btcmi.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import sys
 from pathlib import Path
 
 from btcmi.logging_cfg import configure_logging, new_run_id
@@ -21,7 +22,7 @@ def main() -> int:
     parser_run = subparsers.add_parser(
         "run", help="Produce BTCMI report from input JSON"
     )
-    parser_run.add_argument("--input", required=True)
+    parser_run.add_argument("--input", required=True, help="Input JSON file or '-' for stdin")
     parser_run.add_argument("--out")
     parser_run.add_argument("--fixed-ts", dest="fixed_ts")
     parser_run.add_argument(
@@ -38,7 +39,10 @@ def main() -> int:
     run_id = new_run_id()
 
     if args.cmd == "run":
-        data = load_json(args.input)
+        if args.input == "-":
+            data = json.load(sys.stdin)
+        else:
+            data = load_json(args.input)
         try:
             validate_json(
                 data, Path(__file__).resolve().parents[1] / "input_schema.json"

--- a/tests/test_cli_stdin.py
+++ b/tests/test_cli_stdin.py
@@ -1,0 +1,19 @@
+import io
+import json
+import sys
+from pathlib import Path
+
+import cli.btcmi as btcmi
+
+R = Path(__file__).resolve().parents[1]
+
+
+def test_run_cli_reads_from_stdin(monkeypatch, capsys):
+    data = (R / "examples/intraday.json").read_text()
+    monkeypatch.setattr(sys, "argv", ["btcmi", "run", "--input", "-", "--mode", "v1"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO(data))
+    code = btcmi.main()
+    captured = capsys.readouterr()
+    assert code == 0
+    parsed = json.loads(captured.out)
+    assert parsed["summary"]["scenario"] == "intraday"


### PR DESCRIPTION
## Summary
- allow btcmi CLI to accept JSON from stdin when `--input -`
- document piping usage in README
- test stdin handling through capsys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2fa319f588329b4de7e283c3658b9