### PR TITLE
Offload API runner to background threads

### DIFF
--- a/btcmi/api.py
+++ b/btcmi/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import asyncio
 
 from fastapi import FastAPI, HTTPException, Response
 from pydantic import BaseModel
@@ -79,7 +80,7 @@ async def run_endpoint(payload: RunRequest) -> RunResponse:
     try:
         # API requests should not leave artifacts on disk; explicitly disable
         # writing the output file.
-        result = runner(data, None, out_path=None)
+        result = await asyncio.to_thread(runner, data, None, out_path=None)
     except (KeyError, ValueError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:  # noqa: BLE001

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,6 +21,10 @@ uvicorn btcmi.api:app
 
 Execute an analysis run. The payload must conform to `input_schema.json` and specify the desired mode (`v1` or `v2.fractal`).
 
+The heavy computation is executed in a background thread so the API
+remains responsive and other requests are not blocked while the run is
+in progress.
+
 ### Example
 
 ```bash


### PR DESCRIPTION
## Summary
- make /run endpoint non-blocking by executing runs in `asyncio.to_thread`
- document that heavy computations execute in a background thread

## Testing
- `pytest tests/test_api_app.py`
- `pre-commit run --files btcmi/api.py docs/API.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2faf718588329b43896786ff3f5d0