### PR TITLE
feat: add JSON logging with run metadata

### DIFF
--- a/btcmi/logging_cfg.py
+++ b/btcmi/logging_cfg.py
@@ -1,24 +1,36 @@
-import logging, json, os, sys, time, uuid
+import logging
+import os
+import sys
+import uuid
 
-class JsonFormatter(logging.Formatter):
-    def format(self, record: logging.LogRecord) -> str:
-        rec = {
-            "ts": int(time.time() * 1000),
-            "level": record.levelname.lower(),
-            "msg": record.getMessage(),
-            "run_id": getattr(record, "run_id", None),
-            "mode": getattr(record, "mode", None),
-        }
-        return json.dumps(rec, ensure_ascii=False)
+from pythonjsonlogger import jsonlogger
+
+
+class JSONFormatter(jsonlogger.JsonFormatter):
+    """Format log records as structured JSON."""
+
+    def add_fields(self, log_record, record, message_dict):  # noqa: D401, ANN001
+        """Add custom fields to the log record."""
+        super().add_fields(log_record, record, message_dict)
+        log_record["ts"] = int(record.created * 1000)
+        log_record["level"] = record.levelname.lower()
+        # The base formatter uses the "message" key; rename to "msg"
+        log_record["msg"] = log_record.pop("message", record.getMessage())
+        log_record["run_id"] = getattr(record, "run_id", None)
+        log_record["mode"] = getattr(record, "mode", None)
+        log_record["scenario"] = getattr(record, "scenario", None)
+
 
 def configure_logging() -> None:
     level_name = os.getenv("LOG_LEVEL", "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
     handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(JsonFormatter())
+    handler.setFormatter(JSONFormatter())
     root = logging.getLogger()
     root.setLevel(level)
     root.handlers = [handler]
 
+
 def new_run_id() -> str:
     return uuid.uuid4().hex
+

--- a/cli/btcmi.py
+++ b/cli/btcmi.py
@@ -43,25 +43,31 @@ def main() -> int:
             data = json.load(sys.stdin)
         else:
             data = load_json(args.input)
+        scenario = data.get("scenario")
+        mode = data.get("mode")
         try:
             validate_json(
                 data, Path(__file__).resolve().parents[1] / "input_schema.json"
             )
         except Exception:
             logger.exception(
-                "input_schema_validation_failed", extra={"run_id": run_id}
+                "input_schema_validation_failed",
+                extra={"run_id": run_id, "mode": mode, "scenario": scenario},
             )
             return 2
 
         # If explicit mode present, enforce consistency with --mode argument
-        mode = data.get("mode")
         if mode not in (None, "v1", "v2.fractal"):
             logger.error(
-                "unknown_mode", extra={"run_id": run_id, "mode": mode}
+                "unknown_mode",
+                extra={"run_id": run_id, "mode": mode, "scenario": scenario},
             )
             return 2
         if mode is not None and mode != args.mode:
-            logger.warning("mode_mismatch", extra={"run_id": run_id, "mode": mode})
+            logger.warning(
+                "mode_mismatch",
+                extra={"run_id": run_id, "mode": mode, "scenario": scenario},
+            )
 
         try:
             out = (
@@ -71,7 +77,8 @@ def main() -> int:
             )
         except ValueError:
             logger.exception(
-                "runner_error", extra={"run_id": run_id, "mode": mode}
+                "runner_error",
+                extra={"run_id": run_id, "mode": mode, "scenario": scenario},
             )
             return 2
         try:
@@ -81,7 +88,7 @@ def main() -> int:
         except Exception:
             logger.exception(
                 "output_schema_validation_failed",
-                extra={"run_id": run_id, "mode": mode},
+                extra={"run_id": run_id, "mode": mode, "scenario": scenario},
             )
             return 2
         if args.out is None:
@@ -91,15 +98,21 @@ def main() -> int:
             extra={
                 "run_id": run_id,
                 "mode": args.mode,
+                "scenario": scenario,
             },
         )
         return 0
 
     data = load_json(args.data)
+    scenario = data.get("scenario")
+    mode = data.get("mode")
     try:
         validate_json(data, args.schema)
     except Exception:
-        logger.exception("schema_validation_failed", extra={"run_id": run_id})
+        logger.exception(
+            "schema_validation_failed",
+            extra={"run_id": run_id, "mode": mode, "scenario": scenario},
+        )
         return 2
     print("OK")
     return 0

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -1,0 +1,35 @@
+# Logging configuration
+
+BTCMI uses structured JSON logging powered by
+[`python-json-logger`](https://github.com/madzak/python-json-logger). Each log
+record contains a timestamp (`ts`), level, message, `run_id`, `mode` and
+`scenario` fields to help correlate activity across components.
+
+## CLI example
+
+```bash
+$ LOG_LEVEL=DEBUG btcmi run --input sample.json --mode v1
+{"ts": 1700000000000, "level": "info", "msg": "run_ok", "run_id": "…", "mode": "v1", "scenario": "baseline"}
+```
+
+## FastAPI example
+
+```python
+from btcmi.logging_cfg import configure_logging
+
+configure_logging()
+# proceed to start the application, e.g. with uvicorn
+```
+
+Run the API:
+
+```bash
+$ uvicorn btcmi.api:app
+```
+
+Setting the `LOG_LEVEL` environment variable controls verbosity:
+
+```bash
+$ LOG_LEVEL=WARNING uvicorn btcmi.api:app
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pycoingecko>=3.1.0",
     "docker>=7.1.0",
     "uvicorn>=0.30.1",
+    "python-json-logger>=2.0.7",
 ]
 authors = [{name="BTCMI Team"}]
 license = {text="MIT"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pytest==8.3.3
 # Container & observability
 docker==7.1.0
 uvicorn==0.30.1
+python-json-logger==2.0.7


### PR DESCRIPTION
## Summary
- format logs as JSON and include run metadata
- ensure CLI and API log entries include run_id, mode and scenario
- document logging configuration and usage examples

## Testing
- `pre-commit run --files btcmi/logging_cfg.py cli/btcmi.py btcmi/api.py pyproject.toml requirements.txt docs/LOGGING.md` *(failed: pre-commit not installed)*
- `pip install pre-commit` *(failed: no matching distribution due to proxy restrictions)*
- `pip install python-json-logger>=2.0.7` *(failed: no matching distribution due to proxy restrictions)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'pythonjsonlogger')*

------
https://chatgpt.com/codex/tasks/task_e_68b308fca3bc8329bfdf89cd2ad6e4ee