### PR TITLE
feat: add runner plugin registry

### DIFF
--- a/btcmi/api.py
+++ b/btcmi/api.py
@@ -9,16 +9,10 @@ from typing import Any, Dict
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest
 
 from btcmi.enums import Scenario, Window
-from btcmi.runner import run_v1, run_v2
+from btcmi.runner_registry import RUNNERS
 from btcmi.schema_util import validate_json
 
 app = FastAPI()
-
-# Registry mapping modes to runner implementations
-RUNNERS = {
-    "v1": run_v1,
-    "v2.fractal": run_v2,
-}
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 SCHEMA_REGISTRY = {

--- a/btcmi/runner_registry.py
+++ b/btcmi/runner_registry.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from importlib.metadata import entry_points
+
+from btcmi.runner import run_v1, run_v2
+
+
+def load_runners() -> dict[str, Callable]:
+    """Load runner implementations from entry points.
+
+    The group ``btcmi.runners`` is inspected and all discovered entry points are
+    loaded.  When no entry points are found the built-in runners are returned to
+    maintain backwards compatibility.
+    """
+    try:
+        eps = entry_points()
+        if hasattr(eps, "select"):
+            group = eps.select(group="btcmi.runners")
+        else:  # pragma: no cover - legacy importlib
+            group = eps.get("btcmi.runners", [])
+    except Exception:  # pragma: no cover - defensive
+        group = []
+    runners = {ep.name: ep.load() for ep in group}
+    if not runners:
+        runners = {"v1": run_v1, "v2.fractal": run_v2}
+    return runners
+
+
+RUNNERS = load_runners()
+
+__all__ = ["RUNNERS", "load_runners"]

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,23 @@
+# Runner plugins
+
+The BTCMI tool discovers runner implementations via the `btcmi.runners`
+entry point group.  Third-party packages can register new modes by
+exposing a callable that matches the built-in runners' signature.
+
+## Creating a plugin
+
+1.  Define a function that accepts `(data, fixed_ts, out_path=None)` and
+    returns a BTCMI result.
+2.  Declare the entry point in your project's `pyproject.toml`:
+
+    ```toml
+    [project.entry-points."btcmi.runners"]
+    "my-mode" = "my_package.module:my_runner"
+    ```
+
+3.  Install the package.  The CLI and API will automatically expose the
+    new mode:
+
+    ```bash
+    btcmi run --mode my-mode --input payload.json
+    ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dev = [
 [project.scripts]
 btcmi = "cli.btcmi:main"
 
+[project.entry-points."btcmi.runners"]
+"v1" = "btcmi.runner:run_v1"
+"v2.fractal" = "btcmi.runner:run_v2"
+
 [tool.setuptools.dynamic]
 version = {file = "VERSION"}
 


### PR DESCRIPTION
## Summary
- discover runner implementations via `btcmi.runners` entry points
- use dynamic registry in CLI and API
- document how to create custom plugins

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b30a32f23c8329a6ae55aaed69c252