### PR TITLE
Ensure scenario field exists in JSON logs

### DIFF
--- a/btcmi/logging_cfg.py
+++ b/btcmi/logging_cfg.py
@@ -8,6 +8,7 @@ class JsonFormatter(logging.Formatter):
             "msg": record.getMessage(),
             "run_id": getattr(record, "run_id", None),
             "mode": getattr(record, "mode", None),
+            "scenario": getattr(record, "scenario", None),
         }
         return json.dumps(rec, ensure_ascii=False)
 

--- a/tests/test_logging_cfg.py
+++ b/tests/test_logging_cfg.py
@@ -12,9 +12,10 @@ def test_json_log_format(capsys):
     captured = capsys.readouterr()
     line = captured.err.strip()
     rec = json.loads(line)
-    assert set(rec.keys()) == {"ts", "level", "msg", "run_id", "mode"}
+    assert {"ts", "level", "msg", "run_id", "mode", "scenario"} <= set(rec.keys())
     assert rec["level"] == "info"
     assert rec["msg"] == "hello"
     assert rec["run_id"] == run_id
     assert rec["mode"] == "test"
+    assert rec["scenario"] is None
     assert isinstance(rec["ts"], int)


### PR DESCRIPTION
## Summary
- add `scenario` field to JSON logging formatter
- expand log format test to expect `scenario` key and verify default `None`

## Testing
- `pytest tests/test_logging_cfg.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b30acd2038832988483b0d5ba2ea59