### PR TITLE
chore: pin python-json-logger dependency

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -17,6 +17,7 @@ jsonschema==4.22.0
 prometheus-client==0.19.0
 pycoingecko==3.1.0
 uvicorn==0.30.1
+python-json-logger==2.0.7
 
 # Testing and tooling
 pytest==8.3.3


### PR DESCRIPTION
## Summary
- add python-json-logger to constraints to ensure CI installs it

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b30b8ba5f48329bae80fc5dbf8c757