### PR TITLE
refactor: remove global runners

### DIFF
--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from prometheus_client import CONTENT_TYPE_LATEST
 from prometheus_client.parser import text_string_to_metric_families
 
-from btcmi.api import app, RUNNERS, REQUEST_COUNTER
+from btcmi.api import app, load_runners, REQUEST_COUNTER
 
 R = Path(__file__).resolve().parents[1]
 
@@ -32,7 +32,7 @@ def test_run_runner_exception(monkeypatch):
     def bad_runner(*args, **kwargs):  # pragma: no cover
         raise RuntimeError("boom")
 
-    monkeypatch.setitem(RUNNERS, "v1", bad_runner)
+    monkeypatch.setitem(load_runners(), "v1", bad_runner)
     client = TestClient(app)
     payload = _load_example("intraday")
     resp = client.post("/run", json=payload)
@@ -52,7 +52,7 @@ def test_run_out_path_none(monkeypatch):
             "asof": "1970-01-01T00:00:00Z",
         }
 
-    monkeypatch.setitem(RUNNERS, "v1", runner)
+    monkeypatch.setitem(load_runners(), "v1", runner)
     client = TestClient(app)
     payload = _load_example("intraday")
     resp = client.post("/run", json=payload)

--- a/tests/test_api_snapshots.py
+++ b/tests/test_api_snapshots.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from btcmi.api import app, RUNNERS
+from btcmi.api import app, load_runners
 from btcmi.runner import run_v1, run_v2
 
 R = Path(__file__).resolve().parents[1]
@@ -23,8 +23,8 @@ def _prepare_client(monkeypatch) -> TestClient:
     def r2(p, _t, *, out_path=None):
         return run_v2(p, FIXED_TS, out_path)
 
-    monkeypatch.setitem(RUNNERS, "v1", r1)
-    monkeypatch.setitem(RUNNERS, "v2.fractal", r2)
+    monkeypatch.setitem(load_runners(), "v1", r1)
+    monkeypatch.setitem(load_runners(), "v2.fractal", r2)
     return TestClient(app)
 
 


### PR DESCRIPTION
## Summary
- remove global RUNNERS mapping and introduce cached `load_runners`
- lookup runner dynamically in `/run` handler
- expose `load_runners` and update tests to patch via the loader

## Testing
- `pytest`
- `pre-commit run --files btcmi/api.py tests/test_api_snapshots.py tests/test_api_app.py` *(fails: command not found and installation blocked)*


------
https://chatgpt.com/codex/tasks/task_e_68b311e8d49c8329a5521a5d4729fbdf