### PR TITLE
Refactor tests to patch runner registry

### DIFF
--- a/btcmi/runner_registry.py
+++ b/btcmi/runner_registry.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+from btcmi.runner import run_v1, run_v2
+
+
+# type alias for clarity
+Runner = Callable[[dict, str | None,], dict]
+
+
+def load_runners() -> Dict[str, Callable]:
+    """Return mapping of available runners.
+
+    This indirection allows tests to patch this function to supply custom
+    runner implementations without mutating global state.
+    """
+    return {
+        "v1": run_v1,
+        "v2.fractal": run_v2,
+    }


### PR DESCRIPTION
## Summary
- add runner_registry loader exposing load_runners
- update API to fetch runners via registry
- refactor API tests to patch load_runners with custom dictionaries

## Testing
- `pytest tests/test_api_app.py tests/test_api_snapshots.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3132f5f7883299f451a1ca23239e7