### PR TITLE
Add mypy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,8 @@ repos:
       - id: check-added-large-files
         args: ["--maxkb=2048"]
       - id: detect-private-key
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        args: ['--strict', 'btcmi']


### PR DESCRIPTION
## Summary
- add mypy pre-commit hook running in strict mode on btcmi package

## Testing
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b315ab12b48329ab4c1c18504832b3