### PR TITLE
feat(cli): add JSON error output

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ btcmi run --input examples/intraday.json --out out.json --mode v1
 # Option 3: pipe data via stdin
 cat examples/intraday.json | btcmi run --input - --mode v1
 curl -s https://example.com/intraday.json | btcmi run --input - --mode v1
+# Emit machine-readable errors as JSON
+btcmi run --input bad.json --mode v1 --json-errors
 # Enable Fractal Engine v2
 btcmi run --input examples/intraday_fractal.json --out out_fractal.json --mode v2.fractal
 python tests/validate_output.py out.json  # validate against output_schema.json

--- a/tests/test_cli_required_fields.py
+++ b/tests/test_cli_required_fields.py
@@ -205,3 +205,31 @@ def test_run_cli_prints_json_without_out():
     assert result.returncode == 0
     parsed = json.loads(result.stdout)
     assert parsed["summary"]["scenario"] == "intraday"
+
+
+def test_run_cli_json_errors(tmp_path):
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{}")
+    out = tmp_path / "out.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            CLI,
+            "--json-errors",
+            "run",
+            "--input",
+            str(invalid),
+            "--out",
+            str(out),
+            "--mode",
+            "v1",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    parsed = json.loads(result.stdout)
+    assert parsed["error"] == "input_schema_validation_failed"
+    assert "run_id" in parsed["details"]
+    assert result.stderr == ""


### PR DESCRIPTION
## Summary
- add `--json-errors` flag to emit structured error details
- document JSON error option in CLI usage
- test CLI JSON error parsing

## Testing
- `pytest tests/test_cli_required_fields.py::test_run_cli_json_errors -q`
- `pre-commit run --files cli/btcmi.py README.md tests/test_cli_required_fields.py` *(fails: command not found; pip install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b316b1717c8329b9d53d08247e7091