### PR TITLE
feat: add OpenTelemetry tracing

### DIFF
--- a/btcmi/api.py
+++ b/btcmi/api.py
@@ -5,6 +5,10 @@ import asyncio
 from functools import lru_cache
 
 from fastapi import FastAPI, HTTPException, Response
+try:
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+except Exception:  # pragma: no cover - optional dependency
+    FastAPIInstrumentor = None
 from pydantic import BaseModel
 from typing import Any, Dict, Callable
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest
@@ -14,6 +18,8 @@ from btcmi.runner import run_v1, run_v2
 from btcmi.schema_util import validate_json
 
 app = FastAPI()
+if FastAPIInstrumentor is not None:
+    FastAPIInstrumentor().instrument_app(app)
 
 
 @lru_cache()

--- a/btcmi/logging_cfg.py
+++ b/btcmi/logging_cfg.py
@@ -1,4 +1,27 @@
-import logging, json, os, sys, time, uuid
+import json
+import logging
+import os
+import sys
+import time
+import uuid
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.instrumentation.logging import LoggingInstrumentor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
+        ConsoleSpanExporter,
+        OTLPSpanExporter,
+    )
+except Exception:  # pragma: no cover - opentelemetry is optional
+    trace = None
+    LoggingInstrumentor = None
+    TracerProvider = None
+    BatchSpanProcessor = None
+    ConsoleSpanExporter = None
+    OTLPSpanExporter = None
 
 class JsonFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
@@ -10,6 +33,12 @@ class JsonFormatter(logging.Formatter):
             "mode": getattr(record, "mode", None),
             "scenario": getattr(record, "scenario", None),
         }
+        if trace is not None:
+            span = trace.get_current_span()
+            ctx = span.get_span_context()
+            if ctx.is_valid:
+                rec["trace_id"] = f"{ctx.trace_id:032x}"
+                rec["span_id"] = f"{ctx.span_id:016x}"
         return json.dumps(rec, ensure_ascii=False)
 
 def configure_logging() -> None:
@@ -20,6 +49,19 @@ def configure_logging() -> None:
     root = logging.getLogger()
     root.setLevel(level)
     root.handlers = [handler]
+
+    if LoggingInstrumentor is not None:
+        LoggingInstrumentor().instrument(set_logging_format=False)
+
+    if TracerProvider is not None and BatchSpanProcessor is not None:
+        exporter_name = os.getenv("OTEL_EXPORTER", "console").lower()
+        if exporter_name == "otlp" and OTLPSpanExporter is not None:
+            exporter = OTLPSpanExporter()
+        else:
+            exporter = ConsoleSpanExporter()
+        provider = TracerProvider(resource=Resource.create({"service.name": "btcmi"}))
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        trace.set_tracer_provider(provider)
 
 def new_run_id() -> str:
     return uuid.uuid4().hex

--- a/constraints.txt
+++ b/constraints.txt
@@ -18,6 +18,8 @@ prometheus-client==0.19.0
 pycoingecko==3.1.0
 uvicorn==0.30.1
 python-json-logger==2.0.7
+opentelemetry-sdk==1.26.0
+opentelemetry-instrumentation-fastapi==0.49b0
 
 # Testing and tooling
 pytest==8.3.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "pycoingecko>=3.1.0",
     "docker>=7.1.0",
     "uvicorn>=0.30.1",
+    "opentelemetry-sdk>=1.26.0",
+    "opentelemetry-instrumentation-fastapi>=0.49b0",
 ]
 authors = [{name="BTCMI Team"}]
 license = {text="MIT"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ pytest==8.3.3
 # Container & observability
 docker==7.1.0
 uvicorn==0.30.1
+opentelemetry-sdk==1.26.0
+opentelemetry-instrumentation-fastapi==0.49b0


### PR DESCRIPTION
## Summary
- add OpenTelemetry packages
- instrument FastAPI and logging for tracing and context

## Testing
- `ruff check btcmi/logging_cfg.py btcmi/api.py`
- `mypy btcmi/logging_cfg.py btcmi/api.py`
- `pytest`
- `pip install opentelemetry-sdk opentelemetry-instrumentation-fastapi` *(fails: Could not find a version that satisfies requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68b31821bdd88329ba736152f3821c93