### PR TITLE
docs: add OpenAPI schema and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Production-grade toolkit for Bitcoin market intelligence: strict data contracts,
 * **Data contracts:** `input_schema.json`, `output_schema.json`
 * **Validation & integrity:** structural validator, checksums, SBOM/provenance
 * **Observability:** Prometheus job, Grafana dashboard
-* **HTTP API:** `/run`, `/validate/{schema}`, `/metrics`, `/healthz` ([docs/API.md](docs/API.md))
+* **HTTP API:** `/run`, `/validate/{schema}`, `/metrics`, `/healthz` ([docs/API.md](docs/API.md), [openapi.json](docs/openapi.json))
 * **Containerized runtime:** Docker Compose
 * **Versioning:** update the root `VERSION` file (single source of truth) and sync `CHANGELOG.md`
 * **Conventional Commits** for history hygiene
@@ -66,7 +66,7 @@ Start the HTTP API server:
 uvicorn btcmi.api:app
 ```
 
-Refer to [docs/API.md](docs/API.md) for available endpoints and examples.
+Refer to [docs/API.md](docs/API.md) or the [OpenAPI schema](docs/openapi.json) for available endpoints and examples.
 
 ### Platform notes
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,8 @@
 
 This service exposes a minimal FastAPI interface for running analyses, validating JSON payloads and reporting status.
 
+The OpenAPI schema is available in [openapi.json](openapi.json).
+
 Available endpoints:
 
 - `POST /run` – execute an analysis run.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,280 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/run": {
+      "post": {
+        "summary": "Run Endpoint",
+        "operationId": "run_endpoint_run_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/validate/{schema_name}": {
+      "post": {
+        "summary": "Validate Endpoint",
+        "operationId": "validate_endpoint_validate__schema_name__post",
+        "parameters": [
+          {
+            "name": "schema_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Schema Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ValidateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "summary": "Metrics",
+        "operationId": "metrics_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/healthz": {
+      "get": {
+        "summary": "Healthz",
+        "operationId": "healthz_healthz_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Healthz Healthz Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "RunRequest": {
+        "properties": {
+          "scenario": {
+            "$ref": "#/components/schemas/Scenario"
+          },
+          "window": {
+            "$ref": "#/components/schemas/Window"
+          },
+          "mode": {
+            "type": "string",
+            "title": "Mode",
+            "default": "v1"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "scenario",
+          "window"
+        ],
+        "title": "RunRequest"
+      },
+      "RunResponse": {
+        "properties": {
+          "schema_version": {
+            "type": "string",
+            "title": "Schema Version"
+          },
+          "lineage": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Lineage"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/Summary"
+          },
+          "details": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Details"
+          },
+          "asof": {
+            "type": "string",
+            "title": "Asof"
+          }
+        },
+        "type": "object",
+        "required": [
+          "schema_version",
+          "lineage",
+          "summary",
+          "details",
+          "asof"
+        ],
+        "title": "RunResponse"
+      },
+      "Scenario": {
+        "type": "string",
+        "enum": [
+          "intraday",
+          "scalp",
+          "swing"
+        ],
+        "title": "Scenario"
+      },
+      "Summary": {
+        "properties": {
+          "scenario": {
+            "$ref": "#/components/schemas/Scenario"
+          },
+          "window": {
+            "$ref": "#/components/schemas/Window"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "scenario",
+          "window"
+        ],
+        "title": "Summary"
+      },
+      "ValidateRequest": {
+        "properties": {},
+        "additionalProperties": true,
+        "type": "object",
+        "title": "ValidateRequest"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "Window": {
+        "type": "string",
+        "enum": [
+          "1h",
+          "1d"
+        ],
+        "title": "Window"
+      }
+    }
+  }
+}

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+from fastapi.openapi.utils import get_openapi
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from btcmi.api import app
+
+def main() -> None:
+    spec = get_openapi(
+        title=app.title,
+        version=getattr(app, "version", "0.1.0"),
+        description=app.description,
+        routes=app.routes,
+    )
+    out = ROOT / "docs" / "openapi.json"
+    out.write_text(json.dumps(spec, indent=2), encoding="utf-8")
+    print(out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate OpenAPI schema using FastAPI's get_openapi utility
- document OpenAPI file in README and API guide
- add script to regenerate schema

## Testing
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit (no matching distribution found))*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b325487a248329899d88182082b5ad