### PR TITLE
docs: add architecture and field order docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Production-grade toolkit for Bitcoin market intelligence: strict data contracts,
 * **Containerized runtime:** Docker Compose
 * **Versioning:** update the root `VERSION` file (single source of truth) and sync `CHANGELOG.md`
 * **Conventional Commits** for history hygiene
+* **Documentation:** [Architecture overview](docs/Architecture.md), [JSON field order](docs/FieldOrder.md)
 
 ## Repository layout
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -29,6 +29,19 @@ in progress.
 
 ### Example
 
+**Request**
+
+```json
+{
+  "schema_version": "2.0.0",
+  "lineage": {"run_id": "00000000000000000000000000000000"},
+  "scenario": "intraday",
+  "window": "1h",
+  "mode": "v1",
+  "features": {"btc_price": 30000}
+}
+```
+
 ```bash
 curl -X POST http://localhost:8000/run \
   -H 'Content-Type: application/json' \
@@ -57,6 +70,19 @@ Validate a payload against a registered schema (`input` or `output`).
 
 ### Example
 
+**Request**
+
+```json
+{
+  "schema_version": "2.0.0",
+  "lineage": {"run_id": "00000000000000000000000000000000"},
+  "scenario": "intraday",
+  "window": "1h",
+  "mode": "v1",
+  "features": {"btc_price": 30000}
+}
+```
+
 ```bash
 curl -X POST http://localhost:8000/validate/input \
   -H 'Content-Type: application/json' \
@@ -82,6 +108,8 @@ Prometheus metrics endpoint.
 
 ### Example
 
+**Request**
+
 ```bash
 curl http://localhost:8000/metrics
 ```
@@ -103,6 +131,8 @@ btcmi_requests_total{endpoint="/run"} 1
 Simple health check.
 
 ### Example
+
+**Request**
 
 ```bash
 curl http://localhost:8000/healthz

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,15 @@
+# Architecture
+
+The project combines a command-line interface with an HTTP API and observability stack.
+
+```mermaid
+graph LR
+    CLI[CLI] --> API[HTTP API]
+    API -->|/metrics| Metrics[Prometheus]
+    Metrics --> Grafana
+```
+
+- **CLI** – runs analyses locally or sends requests to the API.
+- **HTTP API** – exposes `/run`, `/validate`, `/metrics`, and `/healthz` endpoints.
+- **Prometheus** – scrapes the API's `/metrics` endpoint.
+- **Grafana** – visualizes metrics collected by Prometheus.

--- a/docs/FieldOrder.md
+++ b/docs/FieldOrder.md
@@ -1,0 +1,27 @@
+# Field Ordering / Порядок полів
+
+## English
+
+To keep JSON data deterministic and easy to review, fields are emitted in a fixed order.
+
+1. `schema_version`
+2. `lineage`
+3. `asof` (when applicable)
+4. Domain fields (`scenario`, `window`, `mode`, ...)
+5. Data blocks (`features` or `summary`, `details`)
+6. Optional fields in alphabetical order
+
+Nested objects follow the same pattern: required fields first, then optional ones alphabetically. Serialize JSON payloads respecting this order.
+
+## Українська
+
+Щоб JSON був детермінованим та зручним для перевірки, поля виводяться у фіксованому порядку.
+
+1. `schema_version`
+2. `lineage`
+3. `asof` (якщо є)
+4. Предметні поля (`scenario`, `window`, `mode` тощо)
+5. Блоки даних (`features` або `summary`, `details`)
+6. Необов'язкові поля за алфавітом
+
+Вкладені об'єкти дотримуються тих самих правил: спочатку обов'язкові, потім необов'язкові поля за алфавітом. Серіалізовані JSON слід формувати з урахуванням цього порядку.


### PR DESCRIPTION
## Summary
- document architecture with CLI, API, Prometheus and Grafana
- describe JSON field ordering in English and Ukrainian
- add concrete request/response examples to API docs and link new docs from README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3266d62fc8329a6a130ead618f4c7