### PR TITLE
ci: add workflows for linting, testing, build and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Generate SBOM
+        run: python scripts/generate_sbom.py
+
+      - name: Compute checksums
+        run: |
+          shasum -a 256 dist/* provenance/sbom.spdx.json > CHECKSUMS.SHA256
+
+      - name: Generate signing key
+        run: |
+          gpg --batch --passphrase '' --quick-gen-key "CI <ci@example.com>" default default
+
+      - name: Sign artifacts
+        run: |
+          for f in dist/* provenance/sbom.spdx.json CHECKSUMS.SHA256; do
+            gpg --batch --yes --armor --detach-sign "$f"
+          done
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: |
+            dist/*
+            CHECKSUMS.SHA256*
+            provenance/sbom.spdx.json*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff black
+
+      - name: Ruff
+        run: ruff check .
+
+      - name: Black
+        run: black --check .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Generate SBOM
+        run: python scripts/generate_sbom.py
+
+      - name: Compute checksums
+        run: |
+          shasum -a 256 dist/* provenance/sbom.spdx.json > CHECKSUMS.SHA256
+
+      - name: Generate signing key
+        run: |
+          gpg --batch --passphrase '' --quick-gen-key "CI <ci@example.com>" default default
+
+      - name: Sign artifacts
+        run: |
+          for f in dist/* provenance/sbom.spdx.json CHECKSUMS.SHA256; do
+            gpg --batch --yes --armor --detach-sign "$f"
+          done
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*
+            CHECKSUMS.SHA256*
+            provenance/sbom.spdx.json*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            if [ -f constraints.txt ]; then
+              pip install -r requirements.txt -c constraints.txt
+            else
+              pip install -r requirements.txt
+            fi
+          fi
+          pip install pytest
+
+      - name: Run tests
+        env:
+          PYTHONPATH: .
+        run: pytest -q --disable-warnings --maxfail=1


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for ruff and black checks
- run pytest across supported Python versions
- build package, generate SBOM, and sign artifacts
- publish signed artifacts to PyPI and GitHub releases

## Testing
- `pytest -q`
- ⚠️ `pre-commit run --files .github/workflows/lint.yml .github/workflows/test.yml .github/workflows/build.yml .github/workflows/release.yml` *(pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3288bbdf48329a15912e8c77d88f7