### PR TITLE
Format codebase with Black and satisfy Ruff lint

### DIFF
--- a/btcmi/api.py
+++ b/btcmi/api.py
@@ -24,6 +24,7 @@ def load_runners() -> Dict[str, Callable]:
         "v2.fractal": run_v2,
     }
 
+
 BASE_DIR = Path(__file__).resolve().parents[1]
 SCHEMA_REGISTRY = {
     "input": BASE_DIR / "input_schema.json",

--- a/btcmi/engine_v2.py
+++ b/btcmi/engine_v2.py
@@ -132,8 +132,6 @@ def combine_levels(L1: float, L2: float, L3: float, w):
     return max(-1.0, min(1.0, s))
 
 
-
-
 def layer_equal_weights(norm: Dict[str, float]) -> Dict[str, float]:
     """Generate equal weights for a layer's features.
 

--- a/btcmi/logging_cfg.py
+++ b/btcmi/logging_cfg.py
@@ -5,6 +5,7 @@ import sys
 import time
 import uuid
 
+
 class JsonFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         rec = {
@@ -17,6 +18,7 @@ class JsonFormatter(logging.Formatter):
         }
         return json.dumps(rec, ensure_ascii=False)
 
+
 def configure_logging() -> None:
     level_name = os.getenv("LOG_LEVEL", "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
@@ -25,6 +27,7 @@ def configure_logging() -> None:
     root = logging.getLogger()
     root.setLevel(level)
     root.handlers = [handler]
+
 
 def new_run_id() -> str:
     return uuid.uuid4().hex

--- a/btcmi/runner.py
+++ b/btcmi/runner.py
@@ -9,6 +9,8 @@ from btcmi import engine_v1 as v1
 from btcmi import engine_v2 as v2
 from btcmi.config import SCENARIO_WEIGHTS
 from btcmi.enums import Scenario, Window
+
+
 def _validate_scenario_window(data: dict) -> tuple[Scenario, Window]:
     """Return the scenario and window ensuring both are valid."""
 
@@ -145,4 +147,3 @@ def run_v2(data, fixed_ts, out_path: str | Path | None = None):
 
 
 __all__ = ["run_v1", "run_v2"]
-

--- a/btcmi/utils.py
+++ b/btcmi/utils.py
@@ -6,4 +6,3 @@ from numbers import Number
 def is_number(x):
     """Return True if *x* is a numeric value (excluding bool)."""
     return isinstance(x, Number) and not isinstance(x, bool)
-

--- a/cli/btcmi.py
+++ b/cli/btcmi.py
@@ -27,7 +27,9 @@ def main() -> int:
     parser_run = subparsers.add_parser(
         "run", help="Produce BTCMI report from input JSON"
     )
-    parser_run.add_argument("--input", required=True, help="Input JSON file or '-' for stdin")
+    parser_run.add_argument(
+        "--input", required=True, help="Input JSON file or '-' for stdin"
+    )
     parser_run.add_argument("--out")
     parser_run.add_argument("--fixed-ts", dest="fixed_ts")
     parser_run.add_argument(

--- a/examples/run_e2e.py
+++ b/examples/run_e2e.py
@@ -21,6 +21,7 @@ from typing import Tuple, List
 ROOT = Path(__file__).resolve().parents[1]
 CLI = "cli.btcmi"
 
+
 def run_example(path: Path) -> Tuple[float, float]:
     """Run CLI for one example file and return predicted and reference signals."""
     data = json.loads(path.read_text(encoding="utf-8"))
@@ -49,6 +50,7 @@ def run_example(path: Path) -> Tuple[float, float]:
     pred = float(out["summary"]["overall_signal"])
     return pred, ref
 
+
 def correlation(xs: List[float], ys: List[float]) -> float:
     """Compute Pearson correlation coefficient between two sequences."""
     if not xs or not ys:
@@ -60,6 +62,7 @@ def correlation(xs: List[float], ys: List[float]) -> float:
     den_y = sum((y - my) ** 2 for y in ys)
     denom = (den_x * den_y) ** 0.5
     return num / denom if denom else 0.0
+
 
 def main() -> int:
     example_dir = Path(__file__).resolve().parent
@@ -81,6 +84,7 @@ def main() -> int:
     print(f"MAE: {mae:.6f}")
     print(f"Correlation: {corr:.6f}")
     return 0
+
 
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())

--- a/ops/metrics/exporter.py
+++ b/ops/metrics/exporter.py
@@ -163,4 +163,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -7,7 +7,8 @@ from fastapi.openapi.utils import get_openapi
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from btcmi.api import app
+from btcmi.api import app  # noqa: E402
+
 
 def main() -> None:
     spec = get_openapi(

--- a/scripts/generate_sbom.py
+++ b/scripts/generate_sbom.py
@@ -3,22 +3,36 @@ import hashlib
 import json
 import time
 from pathlib import Path
+
 ROOT = Path(__file__).resolve().parents[1]
 out = ROOT / "provenance" / "sbom.spdx.json"
 out.parent.mkdir(parents=True, exist_ok=True)
+
+
 def sha256(p: Path) -> str:
-    h=hashlib.sha256()
-    with open(p,"rb") as f:
+    h = hashlib.sha256()
+    with open(p, "rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
             h.update(chunk)
     return h.hexdigest()
-files=[]
+
+
+files = []
 for p in ROOT.rglob("*"):
     if p.is_file():
-        files.append({"fileName": str(p.relative_to(ROOT)),
-                      "checksums":[{"algorithm":"SHA256","checksumValue":sha256(p)}],
-                      "fileSize": p.stat().st_size})
-doc={"spdxVersion":"SPDX-2.3","name":"btcmi","versionInfo":(ROOT/"VERSION").read_text().strip(),
-     "created": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "files": files}
+        files.append(
+            {
+                "fileName": str(p.relative_to(ROOT)),
+                "checksums": [{"algorithm": "SHA256", "checksumValue": sha256(p)}],
+                "fileSize": p.stat().st_size,
+            }
+        )
+doc = {
+    "spdxVersion": "SPDX-2.3",
+    "name": "btcmi",
+    "versionInfo": (ROOT / "VERSION").read_text().strip(),
+    "created": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    "files": files,
+}
 out.write_text(json.dumps(doc, indent=2), encoding="utf-8")
 print(out)

--- a/tests/test_cli_required_fields.py
+++ b/tests/test_cli_required_fields.py
@@ -10,6 +10,7 @@ from btcmi.runner import run_v1, run_v2
 R = Path(__file__).resolve().parents[1]
 CLI = "cli.btcmi"
 
+
 def test_run_v1_missing_scenario(tmp_path):
     data = {"window": "intraday"}
     with pytest.raises(ValueError, match="scenario"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,4 +19,3 @@ def test_is_number_with_numeric_types(val):
 def test_is_number_with_non_numeric_types(val):
     """``is_number`` should return False for non-numeric objects."""
     assert not is_number(val)
-


### PR DESCRIPTION
## Summary
- Add `noqa` to allow path modification before importing in `generate_openapi`
- Format Python files with `black`
- Ensure `ruff` and `black` checks pass

## Testing
- `ruff check .`
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b32a0a84dc8329925753568e293613