### PR TITLE
Validate vol_regime_pctl range and add tests

### DIFF
--- a/btcmi/runner.py
+++ b/btcmi/runner.py
@@ -99,6 +99,8 @@ def run_v2(data, fixed_ts, out_path: str | Path | None = None):
     f2 = data.get("features_mezo", {})
     f3 = data.get("features_macro", {})
     vol_pctl = float(data.get("vol_regime_pctl", 0.5))
+    if not 0.0 <= vol_pctl <= 1.0:
+        raise ValueError("'vol_regime_pctl' must be between 0 and 1 inclusive")
     n1 = v2.normalize_layer(f1, v2.SCALES["L1"])
     n2 = v2.normalize_layer(f2, v2.SCALES["L2"])
     n3 = v2.normalize_layer(f3, v2.SCALES["L3"])

--- a/tests/test_vol_regime_pctl.py
+++ b/tests/test_vol_regime_pctl.py
@@ -1,0 +1,19 @@
+import pytest
+
+from btcmi.runner import run_v2
+
+BASE_DATA = {"scenario": "intraday", "window": "1h"}
+
+
+@pytest.mark.parametrize("pctl, regime", [(0.0, "low"), (1.0, "high")])
+def test_run_v2_vol_regime_pctl_boundaries(pctl, regime):
+    data = dict(BASE_DATA, vol_regime_pctl=pctl)
+    out = run_v2(data, None)
+    assert out["details"]["router_regime"] == regime
+
+
+@pytest.mark.parametrize("pctl", [-0.1, 1.1])
+def test_run_v2_vol_regime_pctl_invalid(pctl):
+    data = dict(BASE_DATA, vol_regime_pctl=pctl)
+    with pytest.raises(ValueError, match="vol_regime_pctl"):
+        run_v2(data, None)


### PR DESCRIPTION
## Summary
- validate `vol_regime_pctl` within [0, 1] in `run_v2`
- raise descriptive error for out-of-range values
- add unit tests covering boundaries and invalid inputs

## Testing
- `pre-commit run --files btcmi/runner.py tests/test_vol_regime_pctl.py` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3492b21088329a8eabde76ae645af