### PR TITLE
Improve JSON loading and schema validation caching

### DIFF
--- a/btcmi/schema_util.py
+++ b/btcmi/schema_util.py
@@ -1,12 +1,21 @@
 from pathlib import Path
 import json
+from json import JSONDecodeError
 
 
 _SCHEMA_CACHE: dict[str, dict] = {}
+_VALIDATOR_CACHE: dict[str, "Draft202012Validator"] = {}
 
 
 def load_json(p):
-    return json.loads(Path(p).read_text(encoding="utf-8"))
+    try:
+        return json.loads(Path(p).read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"JSON file not found: {p}") from exc
+    except JSONDecodeError as exc:
+        raise JSONDecodeError(
+            f"Invalid JSON in {p}: {exc.msg}", exc.doc, exc.pos
+        ) from exc
 
 
 def _load_schema(schema_path):
@@ -25,16 +34,20 @@ def validate_json(data, schema_path):
     ``pip install jsonschema``.
     """
 
-    schema = _load_schema(schema_path)
-    try:
-        from jsonschema import Draft202012Validator
-    except ImportError as exc:  # pragma: no cover - exercised in tests
-        raise ImportError(
-            "jsonschema is required for validate_json. Install with `pip install jsonschema`."
-        ) from exc
+    key = str(schema_path)
+    validator = _VALIDATOR_CACHE.get(key)
+    if validator is None:
+        schema = _load_schema(schema_path)
+        try:
+            from jsonschema import Draft202012Validator
+        except ImportError as exc:  # pragma: no cover - exercised in tests
+            raise ImportError(
+                "jsonschema is required for validate_json. Install with `pip install jsonschema`."
+            ) from exc
+        validator = Draft202012Validator(schema)
+        _VALIDATOR_CACHE[key] = validator
 
-    v = Draft202012Validator(schema)
-    errors = sorted(v.iter_errors(data), key=lambda e: e.path)
+    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
     if errors:
         msgs = []
         for e in errors:

--- a/tests/test_schema_util.py
+++ b/tests/test_schema_util.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from btcmi import schema_util
-from btcmi.schema_util import validate_json
+from btcmi.schema_util import validate_json, load_json
 
 
 def test_validate_json_additional_properties(tmp_path):
@@ -65,3 +65,46 @@ def test_schema_cached(monkeypatch, tmp_path):
     validate_json({}, schema_path)
     validate_json({}, schema_path)
     assert calls == 1
+
+
+def test_load_json_file_not_found(tmp_path):
+    missing = tmp_path / "missing.json"
+    with pytest.raises(FileNotFoundError) as err:
+        load_json(missing)
+    assert str(missing) in str(err.value)
+
+
+def test_load_json_invalid_json(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{bad json}")
+    with pytest.raises(json.JSONDecodeError) as err:
+        load_json(bad)
+    assert "Invalid JSON" in str(err.value)
+
+
+def test_validator_cached(monkeypatch, tmp_path):
+    pytest.importorskip("jsonschema")
+    schema_util._SCHEMA_CACHE.clear()
+    schema_util._VALIDATOR_CACHE.clear()
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+    }
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text(json.dumps(schema))
+
+    class DummyValidator:
+        calls = 0
+
+        def __init__(self, schema):  # noqa: D401 - simple counter
+            DummyValidator.calls += 1
+
+        def iter_errors(self, data):
+            return []
+
+    monkeypatch.setattr(
+        "jsonschema.Draft202012Validator", DummyValidator
+    )
+    validate_json({}, schema_path)
+    validate_json({}, schema_path)
+    assert DummyValidator.calls == 1


### PR DESCRIPTION
## Summary
- add descriptive errors for missing or invalid JSON files
- cache Draft202012Validator instances keyed by schema path
- test load_json error handling and validator caching

## Testing
- `pytest tests/test_schema_util.py`


------
https://chatgpt.com/codex/tasks/task_e_68b34a8ece448329b5255741cfa729d2