### PR TITLE
refactor: centralize schema paths

### DIFF
--- a/btcmi/api.py
+++ b/btcmi/api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 import asyncio
 from functools import lru_cache
 
@@ -11,7 +10,7 @@ from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest
 
 from btcmi.enums import Scenario, Window
 from btcmi.runner import run_v1, run_v2
-from btcmi.schema_util import validate_json
+from btcmi.schema_util import SCHEMA_REGISTRY, validate_json
 
 app = FastAPI()
 
@@ -23,13 +22,6 @@ def load_runners() -> Dict[str, Callable]:
         "v1": run_v1,
         "v2.fractal": run_v2,
     }
-
-
-BASE_DIR = Path(__file__).resolve().parents[1]
-SCHEMA_REGISTRY = {
-    "input": BASE_DIR / "input_schema.json",
-    "output": BASE_DIR / "output_schema.json",
-}
 
 REQUEST_COUNTER = Counter("btcmi_requests_total", "Total HTTP requests", ["endpoint"])
 

--- a/btcmi/schema_util.py
+++ b/btcmi/schema_util.py
@@ -1,7 +1,13 @@
 import json
 from pathlib import Path
 
-__all__ = ["load_json", "_load_schema", "validate_json"]
+BASE_DIR = Path(__file__).resolve().parents[1]
+SCHEMA_REGISTRY = {
+    "input": BASE_DIR / "input_schema.json",
+    "output": BASE_DIR / "output_schema.json",
+}
+
+__all__ = ["load_json", "_load_schema", "validate_json", "SCHEMA_REGISTRY"]
 
 
 _SCHEMA_CACHE: dict[str, dict] = {}

--- a/cli/btcmi.py
+++ b/cli/btcmi.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from btcmi.logging_cfg import configure_logging, new_run_id
 from btcmi.runner import run_v1, run_v2
-from btcmi.schema_util import load_json, validate_json
+from btcmi.schema_util import SCHEMA_REGISTRY, load_json, validate_json
 
 
 def main() -> int:
@@ -57,9 +57,7 @@ def main() -> int:
         else:
             data = load_json(args.input)
         try:
-            validate_json(
-                data, Path(__file__).resolve().parents[1] / "input_schema.json"
-            )
+            validate_json(data, SCHEMA_REGISTRY["input"])
         except Exception:
             report("input_schema_validation_failed", run_id=run_id)
             return 2
@@ -87,9 +85,7 @@ def main() -> int:
             )
             return 2
         try:
-            validate_json(
-                out, Path(__file__).resolve().parents[1] / "output_schema.json"
-            )
+            validate_json(out, SCHEMA_REGISTRY["output"])
         except Exception:
             report(
                 "output_schema_validation_failed",

--- a/tests/test_cli_required_fields.py
+++ b/tests/test_cli_required_fields.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import cli.btcmi as btcmi
 from btcmi.runner import run_v1, run_v2
+from btcmi.schema_util import SCHEMA_REGISTRY
 
 R = Path(__file__).resolve().parents[1]
 CLI = "cli.btcmi"
@@ -57,7 +58,7 @@ def test_validate_cli_returns_code_2(tmp_path):
             CLI,
             "validate",
             "--schema",
-            str(R / "input_schema.json"),
+            str(SCHEMA_REGISTRY["input"]),
             "--data",
             str(invalid),
         ],


### PR DESCRIPTION
## Summary
- centralize schema file locations in `SCHEMA_REGISTRY`
- use shared registry in CLI and API validation
- adjust CLI tests to reference shared schema paths

## Testing
- `pytest`
- `pre-commit run --files btcmi/schema_util.py cli/btcmi.py btcmi/api.py tests/test_cli_required_fields.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b351df293483299c33af3be8748379