### PR TITLE
Add documentation for logging configuration utilities

### DIFF
--- a/btcmi/logging_cfg.py
+++ b/btcmi/logging_cfg.py
@@ -7,6 +7,13 @@ import uuid
 
 
 class JsonFormatter(logging.Formatter):
+    """Format log records as JSON with standard metadata.
+
+    Each record is serialized to JSON with the timestamp (``ts``),
+    log level, message, and optional ``run_id``, ``mode`` and
+    ``scenario`` fields.
+    """
+
     def format(self, record: logging.LogRecord) -> str:
         rec = {
             "ts": int(time.time() * 1000),
@@ -20,6 +27,12 @@ class JsonFormatter(logging.Formatter):
 
 
 def configure_logging() -> None:
+    """Configure root logger to emit JSON-formatted logs to ``stderr``.
+
+    The log level is taken from the ``LOG_LEVEL`` environment variable,
+    defaulting to ``INFO`` if not provided.
+    """
+
     level_name = os.getenv("LOG_LEVEL", "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
     handler = logging.StreamHandler(sys.stderr)
@@ -30,4 +43,6 @@ def configure_logging() -> None:
 
 
 def new_run_id() -> str:
+    """Return a unique identifier for the current run."""
+
     return uuid.uuid4().hex


### PR DESCRIPTION
## Summary
- Document JsonFormatter fields and purpose
- Add docstrings for logging configuration helpers

## Testing
- `pytest`
- `pre-commit run --files btcmi/logging_cfg.py` *(fail: Command not found: pre-commit, installation attempt blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b3530c672c83298f1c09222624f135