### PR TITLE
Use importlib resources for test datasets

### DIFF
--- a/btcmi/examples/intraday.json
+++ b/btcmi/examples/intraday.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "2.0.0",
+  "lineage": {"request_id": "1234567890abcdef1234567890abcdef"},
+  "scenario": "intraday",
+  "window": "1h",
+  "mode": "v1",
+  "features": {
+    "price_change_pct": 0.8,
+    "volume_change_pct": 35.0,
+    "funding_rate_bps": 4.0,
+    "oi_change_pct": 12.0,
+    "onchain_active_addrs_change_pct": 5.0
+  },
+  "nagr_nodes": [
+    {
+      "id": "macro_trend",
+      "weight": 0.6,
+      "score": 0.2
+    },
+    {
+      "id": "liquidity",
+      "weight": 0.4,
+      "score": 0.1
+    }
+  ]
+}

--- a/btcmi/examples/intraday_fractal.json
+++ b/btcmi/examples/intraday_fractal.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "2.0.0",
+  "lineage": {"request_id": "1234567890abcdef1234567890abcdef"},
+  "scenario": "intraday",
+  "window": "1h",
+  "mode": "v2.fractal",
+  "features_micro": {
+    "price_change_pct": 0.8,
+    "volume_change_pct": 35.0,
+    "funding_rate_bps": 4.0,
+    "oi_change_pct": 12.0
+  },
+  "features_mezo": {
+    "oi_term_structure_slope": 0.12,
+    "funding_premium_spread": 0.08
+  },
+  "features_macro": {
+    "active_addrs_trend": 0.1,
+    "macro_regime_score": 0.15
+  },
+  "vol_regime_pctl": 0.55,
+  "nagr_nodes": [
+    {
+      "id": "micro_liquidity",
+      "weight": 0.6,
+      "score": 0.2
+    },
+    {
+      "id": "macro_bias",
+      "weight": 0.4,
+      "score": 0.1
+    }
+  ]
+}

--- a/btcmi/examples/real_intraday.json
+++ b/btcmi/examples/real_intraday.json
@@ -1,0 +1,21 @@
+{
+  "input": {
+    "schema_version": "2.0.0",
+    "lineage": {"request_id": "1234567890abcdef1234567890abcd01"},
+    "scenario": "intraday",
+    "window": "1h",
+    "mode": "v1",
+    "features": {
+      "price_change_pct": 1.2,
+      "volume_change_pct": 45.0,
+      "funding_rate_bps": 3.5,
+      "oi_change_pct": 10.0,
+      "onchain_active_addrs_change_pct": 2.0
+    },
+    "nagr_nodes": [
+      {"id": "macro_trend", "weight": 0.5, "score": 0.1},
+      {"id": "liquidity", "weight": 0.5, "score": 0.2}
+    ]
+  },
+  "reference_overall_signal": 0.15
+}

--- a/btcmi/examples/real_swing.json
+++ b/btcmi/examples/real_swing.json
@@ -1,0 +1,29 @@
+{
+  "input": {
+    "schema_version": "2.0.0",
+    "lineage": {"request_id": "1234567890abcdef1234567890abcd02"},
+    "scenario": "swing",
+    "window": "1d",
+    "mode": "v2.fractal",
+    "features_micro": {
+      "price_change_pct": 2.0,
+      "volume_change_pct": 90.0,
+      "funding_rate_bps": 6.0,
+      "oi_change_pct": 20.0
+    },
+    "features_mezo": {
+      "net_positioning_index": -0.1,
+      "liquidation_heatmap_entropy": 0.25
+    },
+    "features_macro": {
+      "active_addrs_trend": 0.08,
+      "macro_regime_score": 0.3
+    },
+    "vol_regime_pctl": 0.3,
+    "nagr_nodes": [
+      {"id": "deriv_bias", "weight": 0.6, "score": -0.05},
+      {"id": "macro_trend", "weight": 0.4, "score": 0.25}
+    ]
+  },
+  "reference_overall_signal": 0.05
+}

--- a/btcmi/examples/swing_fractal.json
+++ b/btcmi/examples/swing_fractal.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "2.0.0",
+  "lineage": {"request_id": "1234567890abcdef1234567890abcdef"},
+  "scenario": "swing",
+  "window": "1d",
+  "mode": "v2.fractal",
+  "features_micro": {
+    "price_change_pct": 1.5,
+    "volume_change_pct": 80.0,
+    "funding_rate_bps": 8.0,
+    "oi_change_pct": 25.0
+  },
+  "features_mezo": {
+    "net_positioning_index": -0.2,
+    "liquidation_heatmap_entropy": 0.3
+  },
+  "features_macro": {
+    "active_addrs_trend": 0.05,
+    "macro_regime_score": 0.4
+  },
+  "vol_regime_pctl": 0.15,
+  "nagr_nodes": [
+    {
+      "id": "deriv_bias",
+      "weight": 0.5,
+      "score": -0.1
+    },
+    {
+      "id": "macro_trend",
+      "weight": 0.5,
+      "score": 0.2
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ version = {file = "VERSION"}
 "" = ["VERSION"]
 
 [tool.setuptools.package-data]
-btcmi = ["py.typed"]
+btcmi = ["py.typed", "examples/*.json"]
 
 [tool.black]
 line-length = 88

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,8 @@
+import json
+from importlib.resources import files
+
+
+def test_example_data_loads():
+    path = files("btcmi").joinpath("examples/intraday.json")
+    data = json.loads(path.read_text())
+    assert data["mode"] == "v1"


### PR DESCRIPTION
## Summary
- load example datasets in tests via `importlib.resources` instead of `Path`
- package example JSON files with btcmi so tests can access them as resources

## Testing
- `pytest tests/test_data.py`

------
https://chatgpt.com/codex/tasks/task_e_68b3f2fb7bf48329abeaf3a7f11b8ec0