### PR TITLE
Include example data files in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include btcmi/py.typed
-recursive-include examples *
+include examples/*.csv
+include examples/*.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ version = {file = "VERSION"}
 
 [tool.setuptools.package-data]
 btcmi = ["py.typed"]
-examples = ["*"]
+"" = ["examples/*.csv", "examples/*.json"]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Summary
- ensure CSV and JSON examples are packaged by including them in MANIFEST.in
- expose example data via package data settings in pyproject

## Testing
- `pytest`
- `python -m build && wheel unpack dist/*.whl` *(fails: No module named build; unable to install build/wheel due to 403 Forbidden proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fa845a548329aff29164a0923c97