### PR TITLE
ci: enable ruff linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
           fi
           pip install pytest pytest-cov ruff mypy
 
-      - name: Lint with ruff (non-blocking)
-        run: ruff check . || echo "ruff warnings"
+      - name: Lint with ruff
+        run: ruff check .
 
       - name: Type check with mypy
         run: |


### PR DESCRIPTION
## Summary
- run `ruff check .` in CI instead of a non-blocking command

## Testing
- `ruff check .`
- `mypy btcmi`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b408dec1e483298395cd8edc5c5b01