### PR TITLE
Validate vol_regime_pctl input

### DIFF
--- a/btcmi/runner.py
+++ b/btcmi/runner.py
@@ -100,9 +100,12 @@ def run_v2(data, fixed_ts, out_path: str | Path | None = None):
     f1 = data.get("features_micro", {})
     f2 = data.get("features_mezo", {})
     f3 = data.get("features_macro", {})
-    vol_pctl = float(data.get("vol_regime_pctl", 0.5))
+    try:
+        vol_pctl = float(data.get("vol_regime_pctl", 0.5))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("'vol_regime_pctl' must be a number in [0, 1]") from exc
     if not 0.0 <= vol_pctl <= 1.0:
-        raise ValueError("'vol_regime_pctl' must be between 0 and 1 inclusive")
+        raise ValueError("'vol_regime_pctl' must be a number in [0, 1]")
     n1 = v2.normalize_layer(f1, v2.SCALES["L1"])
     n2 = v2.normalize_layer(f2, v2.SCALES["L2"])
     n3 = v2.normalize_layer(f3, v2.SCALES["L3"])

--- a/tests/test_vol_regime_pctl.py
+++ b/tests/test_vol_regime_pctl.py
@@ -17,3 +17,9 @@ def test_run_v2_vol_regime_pctl_invalid(pctl):
     data = dict(BASE_DATA, vol_regime_pctl=pctl)
     with pytest.raises(ValueError, match="vol_regime_pctl"):
         run_v2(data, None)
+
+
+def test_run_v2_vol_regime_pctl_non_numeric():
+    data = dict(BASE_DATA, vol_regime_pctl="invalid")
+    with pytest.raises(ValueError, match="vol_regime_pctl"):
+        run_v2(data, None)


### PR DESCRIPTION
## Summary
- handle non-numeric `vol_regime_pctl` values by raising a clear error
- test string `vol_regime_pctl` values for v2 runner

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b41de01f348329b63a667104786048