### PR TITLE
Validate combine_levels weight handling

### DIFF
--- a/btcmi/engine_v2.py
+++ b/btcmi/engine_v2.py
@@ -128,6 +128,17 @@ def combine_levels(L1: float, L2: float, L3: float, w):
         Combined score clipped to [-1, 1].
 
     """
+    req = {"L1", "L2", "L3"}
+    if not req.issubset(w):
+        missing = ", ".join(sorted(req - w.keys()))
+        raise ValueError(f"missing weights for: {missing}")
+
+    total = w["L1"] + w["L2"] + w["L3"]
+    if math.isclose(total, 0.0, abs_tol=1e-12):
+        raise ValueError("sum of weights must be non-zero")
+    if not math.isclose(total, 1.0, rel_tol=1e-9, abs_tol=1e-9):
+        w = {k: v / total for k, v in w.items()}
+
     s = w["L1"] * L1 + w["L2"] * L2 + w["L3"] * L3
     return max(-1.0, min(1.0, s))
 

--- a/tests/test_engine_v2_layers.py
+++ b/tests/test_engine_v2_layers.py
@@ -74,8 +74,18 @@ def test_router_weights_boundaries(vol_pctl, expected):
 
 
 def test_combine_levels_zero_weights():
-    sig = combine_levels(1.0, -1.0, 0.5, {"L1": 0.0, "L2": 0.0, "L3": 0.0})
-    assert sig == 0.0
+    with pytest.raises(ValueError):
+        combine_levels(1.0, -1.0, 0.5, {"L1": 0.0, "L2": 0.0, "L3": 0.0})
+
+
+def test_combine_levels_normalizes_weights():
+    sig = combine_levels(1.0, 0.0, 0.0, {"L1": 2.0, "L2": 1.0, "L3": 1.0})
+    assert sig == pytest.approx(0.5)
+
+
+def test_combine_levels_missing_weight_raises():
+    with pytest.raises(ValueError):
+        combine_levels(0.0, 0.0, 0.0, {"L1": 0.5, "L2": 0.5})
 
 
 def test_combine_levels_extreme_values_clipped():


### PR DESCRIPTION
## Summary
- Ensure `combine_levels` checks for required level weights
- Normalize weights to sum to one and raise `ValueError` on invalid mappings
- Add tests for weight validation and normalization

## Testing
- `pytest tests/test_engine_v2_layers.py`
- ❌ `pre-commit run --files btcmi/engine_v2.py tests/test_engine_v2_layers.py` *(missing pre-commit; attempted installation but failed with ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_68b4209c4e048329a08a34b250d76714