### PR TITLE
Handle missing CLI files for run and validate commands

### DIFF
--- a/cli/btcmi.py
+++ b/cli/btcmi.py
@@ -70,6 +70,11 @@ def main() -> int:
         else:
             try:
                 data = load_json(args.input)
+            except FileNotFoundError as e:
+                report(
+                    "input_file_not_found", run_id=run_id, path=args.input, message=str(e)
+                )
+                return 2
             except json.JSONDecodeError as e:
                 report("invalid_json", run_id=run_id, message=str(e))
                 return 2
@@ -126,11 +131,21 @@ def main() -> int:
 
     try:
         data = load_json(args.data)
+    except FileNotFoundError as e:
+        report(
+            "data_file_not_found", run_id=run_id, path=str(args.data), message=str(e)
+        )
+        return 2
     except json.JSONDecodeError as e:
         report("invalid_json", run_id=run_id, message=str(e))
         return 2
     try:
         validate_json(data, args.schema)
+    except FileNotFoundError as e:
+        report(
+            "schema_file_not_found", run_id=run_id, path=str(args.schema), message=str(e)
+        )
+        return 2
     except Exception as e:
         report("schema_validation_failed", run_id=run_id, message=str(e))
         return 2

--- a/tests/test_cli_file_not_found.py
+++ b/tests/test_cli_file_not_found.py
@@ -1,0 +1,63 @@
+import subprocess
+import sys
+
+import cli.btcmi as btcmi
+from btcmi.schema_util import SCHEMA_REGISTRY
+
+CLI = "cli.btcmi"
+
+
+def test_run_cli_missing_input(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            CLI,
+            "run",
+            "--input",
+            str(tmp_path / "missing.json"),
+            "--mode",
+            "v1",
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 2
+    assert b"input_file_not_found" in result.stderr
+
+
+def test_validate_cli_missing_schema(tmp_path):
+    data = tmp_path / "data.json"
+    data.write_text("{}")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            CLI,
+            "validate",
+            "--schema",
+            str(tmp_path / "missing-schema.json"),
+            "--data",
+            str(data),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 2
+    assert b"schema_file_not_found" in result.stderr
+
+
+def test_validate_cli_missing_data(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            CLI,
+            "validate",
+            "--schema",
+            str(SCHEMA_REGISTRY["input"]),
+            "--data",
+            str(tmp_path / "missing-data.json"),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 2
+    assert b"data_file_not_found" in result.stderr


### PR DESCRIPTION
## Summary
- gracefully report missing input file for `btcmi run`
- report missing data or schema files for `btcmi validate`
- test CLI behavior when input, schema, or data files are absent

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b43882ac9c8329a56b96f0d2ee0ff4