### PR TITLE
Use lru_cache for schema loading

### DIFF
--- a/btcmi/schema_util.py
+++ b/btcmi/schema_util.py
@@ -1,4 +1,5 @@
 import json
+from functools import lru_cache
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parents[1]
@@ -8,9 +9,6 @@ SCHEMA_REGISTRY = {
 }
 
 __all__ = ["load_json", "_load_schema", "validate_json", "SCHEMA_REGISTRY"]
-
-
-_SCHEMA_CACHE: dict[str, dict] = {}
 
 
 def load_json(path: str | Path) -> dict:
@@ -37,6 +35,7 @@ def load_json(path: str | Path) -> dict:
     return json.loads(Path(path).read_text(encoding="utf-8"))
 
 
+@lru_cache(maxsize=None)
 def _load_schema(schema_path: str | Path) -> dict:
     """Load and cache the JSON schema located at *schema_path*.
 
@@ -58,12 +57,7 @@ def _load_schema(schema_path: str | Path) -> dict:
         If the schema file contains invalid JSON.
     """
 
-    key = str(schema_path)
-    schema = _SCHEMA_CACHE.get(key)
-    if schema is None:
-        schema = load_json(schema_path)
-        _SCHEMA_CACHE[key] = schema
-    return schema
+    return load_json(schema_path)
 
 
 def validate_json(data: dict, schema_path: str | Path) -> None:

--- a/tests/test_schema_util.py
+++ b/tests/test_schema_util.py
@@ -45,7 +45,7 @@ def test_validate_json_without_jsonschema(monkeypatch, tmp_path):
 
 def test_schema_cached(monkeypatch, tmp_path):
     pytest.importorskip("jsonschema")
-    schema_util._SCHEMA_CACHE.clear()
+    schema_util._load_schema.cache_clear()
     schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",


### PR DESCRIPTION
## Summary
- replace manual schema cache with `functools.lru_cache`
- adjust schema caching test for new approach

## Testing
- `pytest tests/test_schema_util.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b44a6f7f3883298e8da33fd3b5965e