### PR TITLE
Annotate linear_score return type

### DIFF
--- a/btcmi/engine_v2.py
+++ b/btcmi/engine_v2.py
@@ -45,7 +45,9 @@ def normalize_layer(
     }
 
 
-def linear_score(norm: Dict[str, float], weights: Dict[str, float]):
+def linear_score(
+    norm: Dict[str, float], weights: Dict[str, float]
+) -> tuple[float, Dict[str, float]]:
     """Compute weighted linear score for normalized features.
 
     Args:
@@ -96,7 +98,11 @@ def nagr(nodes: List[dict]) -> float:
     return max(-1.0, min(1.0, num / den))
 
 
-def level_signal(norm, weights, nagr_nodes):
+def level_signal(
+    norm: Dict[str, float],
+    weights: Dict[str, float],
+    nagr_nodes: List[dict],
+) -> tuple[float, Dict[str, float]]:
     """Blend linear feature score with network rating for one level.
 
     Args:


### PR DESCRIPTION
## Summary
- add explicit tuple return annotation for linear_score
- type level_signal inputs and return for clarity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b46cca1f5c83298d787590ffdf6747