### PR TITLE
Handle CLI output write errors

### DIFF
--- a/cli/btcmi.py
+++ b/cli/btcmi.py
@@ -105,6 +105,14 @@ def main() -> int:
                 message=str(e),
             )
             return 2
+        except (RuntimeError, OSError) as e:
+            report(
+                "output_write_failed",
+                run_id=run_id,
+                path=args.out,
+                message=str(e),
+            )
+            return 2
         if args.mode != "v2.nf3p":
             try:
                 validate_json(out, SCHEMA_REGISTRY["output"])

--- a/tests/test_cli_output_write_error.py
+++ b/tests/test_cli_output_write_error.py
@@ -1,0 +1,38 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+CLI = "cli.btcmi"
+R = Path(__file__).resolve().parents[1]
+
+
+def test_run_cli_output_write_error(tmp_path):
+    data = json.loads((R / "examples/intraday.json").read_text())
+    inp = tmp_path / "in.json"
+    inp.write_text(json.dumps(data))
+    bad_parent = tmp_path / "notadir"
+    bad_parent.write_text("file")
+    out_path = bad_parent / "out.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            CLI,
+            "--json-errors",
+            "run",
+            "--input",
+            str(inp),
+            "--out",
+            str(out_path),
+            "--mode",
+            "v1",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    parsed = json.loads(result.stdout)
+    assert parsed["error"] == "output_write_failed"
+    assert parsed["details"]["path"] == str(out_path)
+    assert result.stderr == ""


### PR DESCRIPTION
## Summary
- Report `output_write_failed` when CLI runner cannot write output files
- Test CLI error reporting for unwritable output paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b46d5e22048329b250038ca09f8c21