### PR TITLE
Pin requirements to constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Ensure requirements match constraints
+        run: |
+          if [ -f requirements.txt ] && [ -f constraints.txt ]; then
+            while IFS= read -r line; do
+              line=$(echo "$line" | xargs)
+              [ -z "$line" ] && continue
+              case "$line" in \#*) continue ;; esac
+              if ! grep -Fxq "$line" constraints.txt; then
+                echo "requirements.txt line '$line' not found in constraints.txt"
+                exit 1
+              fi
+            done < requirements.txt
+          fi
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ requirements.txt
 
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt -c constraints.txt
 pip install -e .
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
-ccxt>=4.2.23
-docker>=7.1.0
-fastapi>=0.111.0
-httpx>=0.27.0
-hypothesis>=6.112.1
-jsonschema>=4.22.0
-numpy>=1.26.4
-opentelemetry-instrumentation-fastapi>=0.48b0
-pandas>=2.2.2
-prometheus-client>=0.19.0
-pycoingecko>=3.1.0
-scipy>=1.14.1
-uvicorn>=0.30.1
+ccxt==4.2.23
+docker==7.1.0
+fastapi==0.111.0
+httpx==0.27.0
+hypothesis==6.112.1
+jsonschema==4.22.0
+numpy==1.26.4
+opentelemetry-instrumentation-fastapi==0.48b0
+pandas==2.2.2
+prometheus-client==0.19.0
+pycoingecko==3.1.0
+scipy==1.14.1
+uvicorn==0.30.1
 


### PR DESCRIPTION
## Summary
- pin requirements.txt packages to exact versions matching constraints
- document installing with constraints in README quickstart
- enforce sync between requirements and constraints in CI

## Testing
- `ruff check .`
- `pytest -q`
- ⚠️ `pip install -r requirements.txt -c constraints.txt` (failed: Cannot connect to proxy)


------
https://chatgpt.com/codex/tasks/task_e_68b47b16a9488329bffecb37f90a7772