### PR TITLE
Handle optional Uvicorn logging

### DIFF
--- a/btcmi/logging_cfg.py
+++ b/btcmi/logging_cfg.py
@@ -6,6 +6,16 @@ import time
 import uuid
 
 
+logger = logging.getLogger(__name__)
+
+try:
+    import uvicorn  # noqa: F401
+except ImportError:
+    logger.warning(
+        "Uvicorn is not installed; skipping Uvicorn-specific logging configuration."
+    )
+
+
 class JsonFormatter(logging.Formatter):
     """Format log records as JSON with standard metadata.
 


### PR DESCRIPTION
## Summary
- log a warning when Uvicorn isn't available
- narrow optional Uvicorn import to ImportError

## Testing
- `ruff check btcmi/logging_cfg.py --fix`
- `black btcmi/logging_cfg.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4824bfd08832987939554e6a020c5