### PR TITLE
Rename Prometheus request counter

### DIFF
--- a/btcmi/api.py
+++ b/btcmi/api.py
@@ -42,7 +42,7 @@ def load_runners() -> Dict[str, Callable]:
     }
 
 
-REQUEST_COUNTER = Counter("btcmi_requests_total", "Total HTTP requests", ["endpoint"])
+REQUEST_COUNTER = Counter("btcmi_requests", "Total HTTP requests", ["endpoint"])
 
 # store recent request timestamps per client for throttling
 _req_times: defaultdict[str, deque] = defaultdict(deque)

--- a/docs/API.md
+++ b/docs/API.md
@@ -131,7 +131,7 @@ curl http://localhost:8000/metrics
 **Response**
 
 ```
-btcmi_requests_total{endpoint="/run"} 1
+btcmi_requests{endpoint="/run"} 1
 ```
 
 **Error codes**


### PR DESCRIPTION
## Summary
- Rename `REQUEST_COUNTER` metric to `btcmi_requests`
- Update metrics documentation for new counter name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b52e93b8988329b550a5f562fe1ce2