### PR TITLE
Expose engine types in API

### DIFF
--- a/btcmi/api.py
+++ b/btcmi/api.py
@@ -24,7 +24,7 @@ from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest
 from pydantic import BaseModel, ConfigDict
 
 from btcmi.enums import Scenario, Window
-from btcmi.runner import run_nf3p, run_v1, run_v2
+from btcmi.runner import Engine, run_nf3p, run_v1, run_v2
 from btcmi.schema_util import SCHEMA_REGISTRY, validate_json
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ app = FastAPI()
 
 
 @lru_cache()
-def load_runners() -> Dict[str, Callable]:
+def load_runners() -> dict[str, Engine]:
     """Return a mapping of mode names to runner implementations."""
     return {
         "v1": run_v1,

--- a/btcmi/runner.py
+++ b/btcmi/runner.py
@@ -3,12 +3,23 @@ from __future__ import annotations
 import datetime as dt
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Protocol
 
 from btcmi import engine_v1 as v1
 from btcmi import engine_v2 as v2
 from btcmi import engine_nf3p as nf3p
 from btcmi.enums import Scenario, Window
+
+
+class Engine(Protocol):
+    def __call__(
+        self,
+        data: dict[str, Any],
+        fixed_ts: str | None,
+        out_path: str | Path | None = None,
+    ) -> dict[str, Any]:
+        """Protocol for engine implementations."""
+        ...
 
 
 def _validate_scenario_window(data: dict) -> tuple[Scenario, Window]:
@@ -194,4 +205,4 @@ def run_nf3p(
     return out
 
 
-__all__ = ["run_v1", "run_v2", "run_nf3p"]
+__all__ = ["Engine", "run_v1", "run_v2", "run_nf3p"]


### PR DESCRIPTION
## Summary
- import Engine protocol for precise runner mapping
- define and export Engine protocol in runner

## Testing
- `pytest`
- `pre-commit run --files btcmi/api.py btcmi/runner.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b534537724832999e3cb6c77cdb8d2