### PR TITLE
refactor: type engine mapping

### DIFF
--- a/btcmi/api.py
+++ b/btcmi/api.py
@@ -24,6 +24,7 @@ from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest
 from pydantic import BaseModel, ConfigDict
 
 from btcmi.enums import Scenario, Window
+from btcmi.engines import Engine
 from btcmi.runner import run_nf3p, run_v1, run_v2
 from btcmi.schema_util import SCHEMA_REGISTRY, validate_json
 
@@ -33,7 +34,7 @@ app = FastAPI()
 
 
 @lru_cache()
-def load_runners() -> Dict[str, Callable]:
+def load_runners() -> dict[str, Engine]:
     """Return a mapping of mode names to runner implementations."""
     return {
         "v1": run_v1,
@@ -152,9 +153,7 @@ async def validate_endpoint(
     if schema_path is None:
         raise HTTPException(status_code=404, detail="schema not found")
     try:
-        await asyncio.to_thread(
-            validate_json, payload.model_dump(), schema_path
-        )
+        await asyncio.to_thread(validate_json, payload.model_dump(), schema_path)
     except Exception as exc:  # noqa: BLE001
         logger.exception("validation_failed")
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -173,4 +172,3 @@ async def healthz() -> dict[str, str]:
 
 
 __all__ = ["app", "load_runners", "REQUEST_COUNTER"]
-

--- a/btcmi/engines/__init__.py
+++ b/btcmi/engines/__init__.py
@@ -1,3 +1,12 @@
-"""Engine run wrappers."""
+"""Engine run wrappers and type definitions."""
 
-__all__ = ["base", "v1", "v2", "nf3p"]
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+
+Engine = Callable[[dict[str, Any], str | None, str | Path | None], dict[str, Any]]
+
+
+__all__ = ["Engine", "base", "v1", "v2", "nf3p"]


### PR DESCRIPTION
## Summary
- import Engine from btcmi.engines
- type load_runners to return mapping of Engine instances
- expose Engine type alias from engines package

## Testing
- `black btcmi/api.py btcmi/engines/__init__.py`
- `ruff check btcmi/api.py btcmi/engines/__init__.py`
- `mypy --strict btcmi` *(fails: Missing type parameters for generic type "dict" and other warnings)*
- `pre-commit run --files btcmi/api.py btcmi/engines/__init__.py` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5372502a483299af7e04ef4ceb1ed