### PR TITLE
feat: annotate engine run methods

### DIFF
--- a/btcmi/engines/base.py
+++ b/btcmi/engines/base.py
@@ -7,6 +7,7 @@ from btcmi import runner
 
 
 def run(
+    self: Any,
     data: dict[str, Any],
     fixed_ts: str | None,
     out_path: str | Path | None = None,

--- a/btcmi/engines/nf3p.py
+++ b/btcmi/engines/nf3p.py
@@ -7,6 +7,7 @@ from btcmi import runner
 
 
 def run(
+    self: Any,
     data: dict[str, Any],
     fixed_ts: str | None,
     out_path: str | Path | None = None,

--- a/btcmi/engines/v1.py
+++ b/btcmi/engines/v1.py
@@ -7,6 +7,7 @@ from btcmi import runner
 
 
 def run(
+    self: Any,
     data: dict[str, Any],
     fixed_ts: str | None,
     out_path: str | Path | None = None,

--- a/btcmi/engines/v2.py
+++ b/btcmi/engines/v2.py
@@ -7,6 +7,7 @@ from btcmi import runner
 
 
 def run(
+    self: Any,
     data: dict[str, Any],
     fixed_ts: str | None,
     out_path: str | Path | None = None,


### PR DESCRIPTION
## Summary
- include `self` parameter in engine wrapper run functions
- ensure runner functions already expose typed signatures

## Testing
- `black btcmi/engines/base.py btcmi/engines/v1.py btcmi/engines/v2.py btcmi/engines/nf3p.py`
- `ruff check btcmi/engines/base.py btcmi/engines/v1.py btcmi/engines/v2.py btcmi/engines/nf3p.py`
- `mypy btcmi`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b539a95e548329b5bebafc03075228