### PR TITLE
refactor: remove redundant json import from nf3p test

### DIFF
--- a/tests/test_runner_nf3p.py
+++ b/tests/test_runner_nf3p.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 import pytest
@@ -9,12 +8,16 @@ R = Path(__file__).resolve().parents[1]
 
 
 def _load_data():
+    import json
+
     data = json.loads((R / "examples/intraday_fractal.json").read_text())
     data["mode"] = "v2.nf3p"
     return data
 
 
 def test_run_nf3p_round_trip(tmp_path, monkeypatch):
+    import json
+
     data = _load_data()
     out_file = tmp_path / "out.json"
 


### PR DESCRIPTION
## Summary
- remove module-level json import in `test_runner_nf3p`
- import json locally inside helper and test functions

## Testing
- `pre-commit run --files tests/test_runner_nf3p.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: could not connect to proxy)*
- `pytest tests/test_runner_nf3p.py`


------
https://chatgpt.com/codex/tasks/task_e_68b53cfd187c8329b2e8601deacdace5