### PR TITLE
Handle zero-scale features safely

### DIFF
--- a/tests/test_feature_processing.py
+++ b/tests/test_feature_processing.py
@@ -1,0 +1,17 @@
+import logging
+import math
+
+import pytest
+
+from btcmi.feature_processing import normalize_features
+
+
+def test_normalize_features_skips_zero_scale(caplog):
+    feats = {"a": 1.0, "b": 2.0}
+    scales = {"a": 0.0, "b": 2.0}
+    with caplog.at_level(logging.DEBUG):
+        norm = normalize_features(feats, scales)
+    assert "a" not in norm
+    assert norm["b"] == pytest.approx(math.tanh(1.0))
+    assert any("zero scale" in m for m in caplog.messages)
+


### PR DESCRIPTION
## Summary
- skip and log features with zero scale during normalization
- add unit test for zero-scale feature handling

## Testing
- `pytest tests/test_feature_processing.py`
- `pre-commit run --files btcmi/feature_processing.py tests/test_feature_processing.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc5e384408329817449f5338634a3