### PR TITLE
Refactor level combiner parameters

### DIFF
--- a/btcmi/engine_v2.py
+++ b/btcmi/engine_v2.py
@@ -83,31 +83,31 @@ def router_weights(vol_pctl: float):
     return "high", {"L1": 0.40, "L2": 0.40, "L3": 0.20}
 
 
-def combine_levels(L1: float, L2: float, L3: float, w):
+def combine_levels(l1: float, l2: float, l3: float, weights: dict[str, float]) -> float:
     """Merge signals from all levels using provided weights.
 
     Args:
-        L1: Level-one signal value.
-        L2: Level-two signal value.
-        L3: Level-three signal value.
-        w: Weight mapping for each level.
+        l1: Level-one signal value.
+        l2: Level-two signal value.
+        l3: Level-three signal value.
+        weights: Weight mapping for each level.
 
     Returns:
         Combined score clipped to [-1, 1].
 
     """
     req = {"L1", "L2", "L3"}
-    if not req.issubset(w):
-        missing = ", ".join(sorted(req - w.keys()))
+    if not req.issubset(weights):
+        missing = ", ".join(sorted(req - weights.keys()))
         raise ValueError(f"missing weights for: {missing}")
 
-    total = w["L1"] + w["L2"] + w["L3"]
+    total = weights["L1"] + weights["L2"] + weights["L3"]
     if math.isclose(total, 0.0, abs_tol=1e-12):
         raise ValueError("sum of weights must be non-zero")
     if not math.isclose(total, 1.0, rel_tol=1e-9, abs_tol=1e-9):
-        w = {k: v / total for k, v in w.items()}
+        weights = {k: v / total for k, v in weights.items()}
 
-    s = w["L1"] * L1 + w["L2"] * L2 + w["L3"] * L3
+    s = weights["L1"] * l1 + weights["L2"] * l2 + weights["L3"] * l3
     return max(-1.0, min(1.0, s))
 
 

--- a/btcmi/runner.py
+++ b/btcmi/runner.py
@@ -121,8 +121,8 @@ def run_v2(
     s1, _ = v2.level_signal(n1, w1, data.get("nagr_nodes", []))
     s2, _ = v2.level_signal(n2, w2, data.get("nagr_nodes", []))
     s3, _ = v2.level_signal(n3, w3, data.get("nagr_nodes", []))
-    regime, alphas = v2.router_weights(vol_pctl)
-    overall = v2.combine_levels(s1, s2, s3, alphas)
+    regime, weights = v2.router_weights(vol_pctl)
+    overall = v2.combine_levels(s1, s2, s3, weights=weights)
     coverage = sum(len(x) > 0 for x in [n1, n2, n3]) / 3.0
     conf = round(0.5 + 0.5 * min(coverage, 1.0), 3)
     notes: list[str] = []
@@ -142,7 +142,7 @@ def run_v2(
             "overall_signal_L1": round(s1, 6),
             "overall_signal_L2": round(s2, 6),
             "overall_signal_L3": round(s3, 6),
-            "level_weights": alphas,
+            "level_weights": weights,
         },
         "details": {
             "normalized_micro": {k: round(v, 6) for k, v in n1.items()},

--- a/tests/test_engine_v2_layers.py
+++ b/tests/test_engine_v2_layers.py
@@ -75,23 +75,25 @@ def test_router_weights_boundaries(vol_pctl, expected):
 
 def test_combine_levels_zero_weights():
     with pytest.raises(ValueError):
-        combine_levels(1.0, -1.0, 0.5, {"L1": 0.0, "L2": 0.0, "L3": 0.0})
+        combine_levels(1.0, -1.0, 0.5, weights={"L1": 0.0, "L2": 0.0, "L3": 0.0})
 
 
 def test_combine_levels_normalizes_weights():
-    sig = combine_levels(1.0, 0.0, 0.0, {"L1": 2.0, "L2": 1.0, "L3": 1.0})
+    sig = combine_levels(1.0, 0.0, 0.0, weights={"L1": 2.0, "L2": 1.0, "L3": 1.0})
     assert sig == pytest.approx(0.5)
 
 
 def test_combine_levels_missing_weight_raises():
     with pytest.raises(ValueError):
-        combine_levels(0.0, 0.0, 0.0, {"L1": 0.5, "L2": 0.5})
+        combine_levels(0.0, 0.0, 0.0, weights={"L1": 0.5, "L2": 0.5})
 
 
 def test_combine_levels_extreme_values_clipped():
-    sig = combine_levels(10.0, -10.0, 10.0, {"L1": 0.3, "L2": 0.3, "L3": 0.4})
+    sig = combine_levels(10.0, -10.0, 10.0, weights={"L1": 0.3, "L2": 0.3, "L3": 0.4})
     assert sig == 1.0
-    sig_neg = combine_levels(-10.0, -10.0, -10.0, {"L1": 0.3, "L2": 0.3, "L3": 0.4})
+    sig_neg = combine_levels(
+        -10.0, -10.0, -10.0, weights={"L1": 0.3, "L2": 0.3, "L3": 0.4}
+    )
     assert sig_neg == -1.0
 
 


### PR DESCRIPTION
## Summary
- rename `combine_levels` parameters to `l1`, `l2`, and `l3`
- annotate the `weights` parameter and update call sites

## Testing
- `pytest`
- `pre-commit run --files btcmi/engine_v2.py btcmi/runner.py tests/test_engine_v2_layers.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc5e4a6a883299152984e9e5df0f9