### PR TITLE
refactor: centralize NAGR computation

### DIFF
--- a/btcmi/engine_v1.py
+++ b/btcmi/engine_v1.py
@@ -3,16 +3,13 @@
 from __future__ import annotations
 from typing import Dict, Any
 from dataclasses import dataclass
-import logging
 from btcmi.utils import is_number
 from btcmi.config import NORM_SCALE, SCENARIO_WEIGHTS
 from btcmi.feature_processing import normalize_features, weighted_score
+from btcmi.nagr import nagr
 
 
 FeatureMap = Dict[str, float]
-
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -22,6 +19,7 @@ class BaseSignalResult:
     score: float
     weights: FeatureMap
     contributions: FeatureMap
+
 
 def normalize(features: FeatureMap) -> FeatureMap:
     """Scale raw feature values using hyperbolic tangent."""
@@ -69,22 +67,9 @@ def nagr_score(nodes: Any) -> float:
 
     Returns:
         Weighted average score clipped to [-1, 1].
-
     """
-    if not nodes:
-        return 0.0
-    num = 0.0
-    den = 0.0
-    for n in nodes:
-        try:
-            w = float(n.get("weight", 0.0))
-            sc = float(n.get("score", 0.0))
-        except (TypeError, ValueError) as exc:
-            logger.debug("Skipping node with non-numeric data %s: %s", n, exc)
-            continue
-        num += w * sc
-        den += abs(w)
-    return max(-1.0, min(1.0, num / den if den else 0.0))
+
+    return nagr(nodes)
 
 
 def combine(base: float, nagr: float) -> float:

--- a/btcmi/engine_v2.py
+++ b/btcmi/engine_v2.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 from typing import Dict, List
 import math
-import logging
 from btcmi.config import SCALES as CONFIG_SCALES
 from btcmi.feature_processing import normalize_features, weighted_score
+from btcmi.nagr import nagr
 
 SCALES = CONFIG_SCALES
-logger = logging.getLogger(__name__)
 
 
 def normalize_layer(
@@ -17,33 +16,6 @@ def normalize_layer(
     """Apply normalization to a layer's feature set."""
 
     return normalize_features(feats, scales)
-
-
-def nagr(nodes: List[dict]) -> float:
-    """Aggregate network graph ratings.
-
-    Args:
-        nodes: Sequence of node dicts with ``weight`` and ``score``.
-
-    Returns:
-        Weighted average score clipped to [-1, 1].
-
-    """
-    if not nodes:
-        return 0.0
-    num = 0.0
-    den = 0.0
-    for n in nodes:
-        try:
-            w = float(n.get("weight", 0.0))
-            sc = float(n.get("score", 0.0))
-        except (TypeError, ValueError) as exc:
-            logger.debug("Skipping node with non-numeric data %s: %s", n, exc)
-            continue
-        num += w * sc
-        den += abs(w)
-    den = den or 1.0
-    return max(-1.0, min(1.0, num / den))
 
 
 def level_signal(

--- a/btcmi/nagr.py
+++ b/btcmi/nagr.py
@@ -1,0 +1,40 @@
+"""Shared utilities for NAGR (network aggregated graph rating) computation."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Any
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def nagr(nodes: Iterable[Mapping[str, Any]]) -> float:
+    """Aggregate network graph ratings.
+
+    Args:
+        nodes: Iterable of node dictionaries with ``weight`` and ``score``.
+
+    Returns:
+        Weighted average score clipped to [-1, 1].
+    """
+
+    if not nodes:
+        return 0.0
+
+    num = 0.0
+    den = 0.0
+    for n in nodes:
+        try:
+            w = float(n.get("weight", 0.0))
+            sc = float(n.get("score", 0.0))
+        except (TypeError, ValueError) as exc:
+            logger.debug("Skipping node with non-numeric data %s: %s", n, exc)
+            continue
+        num += w * sc
+        den += abs(w)
+
+    den = den or 1.0
+    return max(-1.0, min(1.0, num / den))
+
+
+__all__ = ["nagr"]

--- a/tests/test_nagr.py
+++ b/tests/test_nagr.py
@@ -1,0 +1,22 @@
+import pytest
+
+from btcmi.nagr import nagr
+
+
+def test_nagr_handles_empty_and_zero_weights():
+    assert nagr([]) == 0.0
+    assert nagr([{"weight": 0.0, "score": 1.0}]) == 0.0
+
+
+def test_nagr_clips_extreme():
+    nodes = [{"weight": 1.0, "score": 2.0}]
+    assert nagr(nodes) == 1.0
+
+
+def test_nagr_skips_non_numeric_nodes():
+    nodes = [
+        {"weight": 1.0, "score": 0.5},
+        {"weight": "bad", "score": 1.0},
+        {"weight": 1.0, "score": "bad"},
+    ]
+    assert nagr(nodes) == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- extract shared NAGR scoring utility used by both engine versions
- refactor engine_v1 and engine_v2 to delegate to shared `nagr` function
- add unit tests for NAGR utility

## Testing
- `python -m black btcmi/nagr.py btcmi/engine_v1.py btcmi/engine_v2.py tests/test_nagr.py`
- `python -m ruff check btcmi/nagr.py btcmi/engine_v1.py btcmi/engine_v2.py tests/test_nagr.py`
- `python -m mypy btcmi`
- `pytest -q`
- `pre-commit run --files btcmi/nagr.py btcmi/engine_v1.py btcmi/engine_v2.py tests/test_nagr.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc5e515bc8329be187ffba811b982