### PR TITLE
Refine uvicorn logging configuration

### DIFF
--- a/btcmi/logging_cfg.py
+++ b/btcmi/logging_cfg.py
@@ -9,13 +9,6 @@ import uuid
 logger = logging.getLogger(__name__)
 _LOGGING_CONFIGURED = False
 
-try:
-    import uvicorn  # noqa: F401
-except ImportError:
-    logger.warning(
-        "Uvicorn is not installed; skipping Uvicorn-specific logging configuration."
-    )
-
 
 class JsonFormatter(logging.Formatter):
     """Format log records as JSON with standard metadata.
@@ -56,6 +49,13 @@ def configure_logging() -> None:
     root = logging.getLogger()
     root.setLevel(level)
     root.handlers = [handler]
+    try:
+        import uvicorn  # noqa: F401
+    except ImportError:
+        logger.debug(
+            "Uvicorn is not installed; skipping Uvicorn-specific logging configuration."
+        )
+
     _LOGGING_CONFIGURED = True
 
 


### PR DESCRIPTION
## Summary
- Move uvicorn presence check into `configure_logging` and log at debug-level when missing
- Make importing `logging_cfg` side-effect free
- Add tests covering import side-effects and uvicorn debug message

## Testing
- `pytest -q`
- `pre-commit run --files btcmi/logging_cfg.py tests/test_logging_cfg.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc5e779448329815fce792b834050