### PR TITLE
ci: remove invalid fail-on-error; zipci: escape expression tokens in sed

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci_failure.md
+++ b/.github/ISSUE_TEMPLATE/ci_failure.md
@@ -1,0 +1,3 @@
+CI run: ${{ RUN_URL }}
+Branch: ${{ PR_BRANCH }}
+Artifact: ${{ ZIP_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,52 @@ on:
     branches: [ "main" ]
 
 jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install ruff
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Lint with ruff
+        run: ruff check .
+
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # якщо є requirements.txt/constraints.txt — встановимо
+          if [ -f requirements.txt ]; then
+            if [ -f constraints.txt ]; then
+              pip install -r requirements.txt -c constraints.txt
+            else
+              pip install -r requirements.txt
+            fi
+          fi
+          pip install mypy
+      - name: Type check with mypy
+        run: |
+          if [ -d "btcmi" ]; then
+            mypy btcmi
+          fi
+
   build-test:
     runs-on: ubuntu-latest
+    needs:
+      - ruff
+      - mypy
     strategy:
       matrix:
         python-version: [ "3.10", "3.11", "3.12" ]
@@ -48,16 +92,7 @@ jobs:
               pip install -r requirements.txt
             fi
           fi
-          pip install pytest pytest-cov ruff mypy
-
-      - name: Lint with ruff
-        run: ruff check .
-
-      - name: Type check with mypy
-        run: |
-          if [ -d "btcmi" ]; then
-            mypy btcmi
-          fi
+          pip install pytest pytest-cov
 
       - name: Run schema freeze test
         env:

--- a/.github/workflows/zipci.yml
+++ b/.github/workflows/zipci.yml
@@ -1,0 +1,26 @@
+name: ZIPCI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "validate"
+
+  report:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare Issue body
+        if: needs.validate.result != 'success'
+        shell: bash
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_BRANCH: zipci/${{ github.run_id }}
+          ZIP_NAME: ${{ github.event.head_commit.message || 'ZIP' }}
+        run: |
+          sed -e "s|$${{ RUN_URL }}|$RUN_URL|g" \
+              -e "s|$${{ PR_BRANCH }}|$PR_BRANCH|g" \
+              -e "s|$${{ ZIP_NAME }}|$ZIP_NAME|g" .github/ISSUE_TEMPLATE/ci_failure.md > ISSUE_BODY.md


### PR DESCRIPTION
## Summary
- run lint and type check in dedicated jobs without invalid `fail-on-error`
- escape expression tokens in ZIPCI workflow sed usage and template

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/zipci.yml .github/ISSUE_TEMPLATE/ci_failure.md` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bfcf66e2d08329bc9c7b59175dc5c9